### PR TITLE
Fixed readme and makefile to make first-run easier.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 server: dependencies
-	@up -t 0 -n 1 -w -p 3000 server.js
+	node_modules/.bin/up -t 0 -n 1 -w -p ${OPENBADGER_PORT} server.js
 
 dependencies:
 	@npm install

--- a/README.md
+++ b/README.md
@@ -2,23 +2,15 @@
 
 Badging for webmaker.
 
-# Installing deps & starting the server
+# Prerequisites
 
-```bash
-$ make     # will do `npm install` and then start server
-```
-
-# Running the test suite
-
-```bash
-$ make test         # normally you'd use this
-$ make verbose-test # if you want to see debugging
-$ make lint         # to lint the codebase
-```
+Make sure you have [redis](http://redis.io) and [mongo](http://mongodb.org/)
+installed or hosted somewhere. You'll also need node.
 
 # Local configuration
-Here is an example configuration. This assumes you are running
-[redis](http://redis.io) and [mongo](http://mongodb.org/) locally.
+
+Here is an example configuration. This assumes you are running redis
+and mongo locally.
 
 ```bash
 export OPENBADGER_HOST="localhost"
@@ -39,6 +31,20 @@ that in a file and `source` it. For example, if you save a version of this at `c
 
 ```bash
 $ source config.sh
+```
+
+# Installing deps & starting the server
+
+```bash
+$ make     # will do `npm install` and then start server
+```
+
+# Running the test suite
+
+```bash
+$ make test         # normally you'd use this
+$ make verbose-test # if you want to see debugging
+$ make lint         # to lint the codebase
 ```
 
 # Heroku configuration


### PR DESCRIPTION
Specifically, use OPENBADGER_PORT to with up, call up via node_modules/.bin,
and move stuff around in README.md to make order of steps to get started
a bit more logical.
