### PR TITLE
Make dl not wrap around bottom of badge image

### DIFF
--- a/public/stylesheets/admin.css
+++ b/public/stylesheets/admin.css
@@ -63,6 +63,10 @@
   height: 133px;
 }
 
+.show-badge dl {
+  overflow: hidden;
+}
+
 .show-badge dt, .show-badge dd {
   margin-bottom: 4px;
 }


### PR DESCRIPTION
Poor man's media block. [Explanation](http://www.stubbornella.org/content/2009/07/23/overflow-a-secret-benefit/) of why this works for those interested.
