### PR TITLE
Criteria font fix

### DIFF
--- a/public/stylesheets/criteria.css
+++ b/public/stylesheets/criteria.css
@@ -42,14 +42,17 @@ hgroup span {
 }
 
 h1 {
-  font-family: "Open Sans Light", sans-serif;
+  font-family: "Open Sans Light Bold", sans-serif;
+  -webkit-font-smoothing: auto;
+  font-weight: 100;
   font-size: 46px;
   margin-bottom: 0.8em;
 }
 h2 {
   font-family: "Open Sans Light", sans-serif;
-  color: #4199D6;
+  -webkit-font-smoothing: auto;
   font-weight: 100;
+  color: #4199D6;
 }
 
 .wordmark + h1 {

--- a/public/stylesheets/criteria.css
+++ b/public/stylesheets/criteria.css
@@ -41,17 +41,17 @@ hgroup span {
   margin-top: 45px;
 }
 
-h1 {
-  font-family: "Open Sans Light Bold", sans-serif;
+h1, h2 {
   -webkit-font-smoothing: auto;
-  font-weight: 100;
+  font-weight: 100;  
+}
+h1 {
+  font-family: "Open Sans Bold", sans-serif;
   font-size: 46px;
   margin-bottom: 0.8em;
 }
 h2 {
   font-family: "Open Sans Light", sans-serif;
-  -webkit-font-smoothing: auto;
-  font-weight: 100;
   color: #4199D6;
 }
 


### PR DESCRIPTION
This homogenises the font for the criteria page by forcing all browsers to use Open Sans Bold at font weight 100, with webkit browsers forced to use "auto" smoothing (contrary to the name, that's not what they use by default). This makes it all look like the screenshot @iamjessklein indicated as looking correct (http://i.imgur.com/ojpok.png)
