### PR TITLE
no text wordmarks anymore

### DIFF
--- a/public/stylesheets/criteria.css
+++ b/public/stylesheets/criteria.css
@@ -12,10 +12,6 @@ p, dl {
   width: 200px;
 }
 
-.wordmark {
-  text-transform: lowercase;
-}
-
 hgroup span {
   margin-bottom: 0;
 }
@@ -46,15 +42,11 @@ h1 {
   font-size: 46px;
   margin-bottom: 0.8em;
 }
+
 h2 {
   font-family: "Open Sans Light", sans-serif;
   color: #4199D6;
   font-weight: 100;
-}
-
-.wordmark + h1 {
-  margin-top: 0;
-  line-height: 38px;
 }
 
 h3 {

--- a/views/public/all.html
+++ b/views/public/all.html
@@ -22,7 +22,6 @@
     <img class="img badge" src="{{ badge.relativeUrl('image')}}">
     <div class="bd">
       <hgroup>
-        <span class="wordmark">Mozilla</span>
         <h1>{{ badge.name }}</h1>
       </hgroup>
       <dl class="dl-horizontal narrow-dt">

--- a/views/public/confirm-claim.html
+++ b/views/public/confirm-claim.html
@@ -12,7 +12,6 @@
     <img class="img badge" src="{{ badge.relativeUrl('image')}}">
     <div class="bd">
       <hgroup>
-        <span class="wordmark">Mozilla</span>
         <h1>{{ badge.name }}</h1>
       </hgroup>
       <dl class="dl-horizontal narrow-dt">

--- a/views/public/criteria.html
+++ b/views/public/criteria.html
@@ -12,7 +12,6 @@
     <img class="img badge" src="{{ badge.relativeUrl('image')}}">
     <div class="bd">
       <hgroup>
-        <span class="wordmark">Mozilla</span>
         <h1>{{ badge.name }}</h1>
       </hgroup>
       <dl class="dl-horizontal narrow-dt">


### PR DESCRIPTION
Removed the "wordmark" text spans ("used in place of the mozilla text logo) from the three pages that used it.
