### PR TITLE
API endpoint for getting claim codes.

### DIFF
--- a/app.js
+++ b/app.js
@@ -157,17 +157,31 @@ app.delete('/admin/users', user.deleteInstancesByEmail);
 // API endpoints
 // -------------
 app.get('/v2/badges', api.badges);
-app.get('/v2/user', [api.auth], api.user);
-app.post('/v2/user/behavior/:behavior/credit', [api.auth], api.credit);
-app.post('/v2/user/mark-all-badges-as-read',
-         [api.auth],
-         api.markAllBadgesAsRead);
+
+app.get('/v2/user', [
+  api.auth()
+], api.user);
+
+app.get('/v2/badge/:shortname/claimcodes', [
+  api.auth({user: false}),
+  findBadgeByParamShortname,
+], api.badgeClaimCodes);
+
+app.post('/v2/user/behavior/:behavior/credit', [
+  api.auth()
+], api.credit);
+
+app.post('/v2/user/mark-all-badges-as-read',[
+  api.auth()
+],api.markAllBadgesAsRead);
 
 // Debug endpoints
 // ---------------
 app.configure('development', function () {
   app.get('/debug/flush', admin.showFlushDbForm);
   app.post('/debug/flush', debug.flushDb);
+  app.get('/debug/token', debug.generateToken);
+  app.post('/debug/token', debug.generateToken);
 });
 
 var server = module.exports = http.createServer(app);

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,6 @@
-var util = require('util');
-var crypto = require('crypto');
+const _ = require('underscore');
+const util = require('util');
+const crypto = require('crypto');
 
 util.alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890';
 
@@ -123,6 +124,16 @@ util.uid = function uid(len) {
   return crypto.randomBytes(Math.ceil(len * 3 / 4))
     .toString('base64')
     .slice(0, len);
+};
+
+
+util.pager = function (array, opts) {
+  opts = _.defaults(opts, { page: 1, count: 10, });
+  const page = opts.page;
+  const count = opts.count;
+  const begin = (page - 1) * count;
+  const end = page * count;
+  return array.slice(begin, end);
 };
 
 module.exports = util;

--- a/models/badge.js
+++ b/models/badge.js
@@ -1,10 +1,11 @@
-var db = require('./');
-var mongoose = require('mongoose');
-var env = require('../lib/environment');
-var util = require('../lib/util');
-var Issuer = require('./issuer');
-var phraseGenerator = require('../lib/phrases');
-var Schema = mongoose.Schema;
+const _ = require('underscore');
+const db = require('./');
+const mongoose = require('mongoose');
+const env = require('../lib/environment');
+const util = require('../lib/util');
+const Issuer = require('./issuer');
+const phraseGenerator = require('../lib/phrases');
+const Schema = mongoose.Schema;
 
 function maxLength(field, length) {
   function lengthValidator() {
@@ -305,10 +306,18 @@ Badge.prototype.getClaimCode = function getClaimCode(code) {
   return null;
 };
 
-Badge.prototype.getClaimCodes = function getClaimCodes() {
+Badge.prototype.getClaimCodes = function getClaimCodes(opts) {
+  opts = _.defaults(opts||{}, {unclaimed: false});
+  const onlyShowUnclaimed = opts.unclaimed || false;
   const codes = this.claimCodes;
-  return codes.map(function (entry) {
-    return entry.code;
+  
+  var filterFn = function () { return true };
+  
+  if (onlyShowUnclaimed)
+    filterFn = function (entry) { return !entry.claimedBy };
+  
+  return codes.filter(filterFn).map(function (entry) {
+    return { code: entry.code, claimed: !!entry.claimedBy };
   });
 };
 

--- a/models/badge.js
+++ b/models/badge.js
@@ -308,13 +308,11 @@ Badge.prototype.getClaimCode = function getClaimCode(code) {
 
 Badge.prototype.getClaimCodes = function getClaimCodes(opts) {
   opts = _.defaults(opts||{}, {unclaimed: false});
-  const onlyShowUnclaimed = opts.unclaimed || false;
   const codes = this.claimCodes;
   
-  var filterFn = function () { return true };
-  
-  if (onlyShowUnclaimed)
-    filterFn = function (entry) { return !entry.claimedBy };
+  var filterFn = opts.unclaimed
+    ? function (o) { return !o.claimedBy }
+    : function (o) { return true };
   
   return codes.filter(filterFn).map(function (entry) {
     return { code: entry.code, claimed: !!entry.claimedBy };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "sandwich": "~0.1.1",
     "optimist": "~0.3.5",
     "iterator-stream": "~0.4.0",
-    "markdown": "~0.4.0"
+    "markdown": "~0.4.0",
+    "underscore": "~1.4.4"
   },
   "devDependencies": {
     "tap": "~0.3.1"

--- a/routes/api.js
+++ b/routes/api.js
@@ -1,10 +1,11 @@
-var jwt = require('jwt-simple');
-var urlutil = require('url');
-var env = require('../lib/environment');
-var util = require('../lib/util');
-var Badge = require('../models/badge');
-var User = require('../models/user');
-var BadgeInstance = require('../models/badge-instance');
+const _ = require('underscore');
+const jwt = require('jwt-simple');
+const urlutil = require('url');
+const env = require('../lib/environment');
+const util = require('../lib/util');
+const Badge = require('../models/badge');
+const User = require('../models/user');
+const BadgeInstance = require('../models/badge-instance');
 
 /**
  * Get listing of all badges
@@ -30,6 +31,41 @@ exports.badges = function badges(req, res) {
       };
     });
     return res.send(200, result);
+  });
+};
+
+exports.badgeClaimCodes = function badgeClaimCodes(req, res, next) {
+  const badge = req.badge;
+  const queryOpts = req.query;
+  
+  // theoretically this should never happen - this route should always
+  // be preceded by middleware that finds the badge or 404s.
+  if (!badge)
+    return res.json(404, {status: 'error', reason: 'badge not found'});
+  
+  const options = {
+    page: parseInt(queryOpts.page, 10) || 1,
+    count: parseInt(queryOpts.count, 10) || 100,
+    unclaimed: false,
+  };
+  
+  if (queryOpts.count === '0' || queryOpts.limit === 'false')
+    options.count = Infinity;
+  
+  const allCodes = badge.getClaimCodes({
+    unclaimed: options.unclaimed
+  });
+  const someCodes = util.pager(allCodes, {
+    page: options.page,
+    count: options.count
+  });
+  
+  return res.json(200, {
+    status: 'ok',
+    total: allCodes.length,
+    claimcodes: someCodes,
+    page: options.page,
+    count: options.count,
   });
 };
 
@@ -147,29 +183,42 @@ exports.markAllBadgesAsRead = function markAllBadgesAsRead(req, res) {
  * JWT param and confirming audience and issuer.
  */
 
-exports.auth = function auth(req, res, next) {
-  var param = req.method === "POST" ? req.body : req.query;
-  var token = param.auth;
-  var email = param.email;
-  var issuer = req.issuer;
-  var secret = issuer.jwtSecret;
-  var origin = env.origin();
-  var isXHR = req.headers['x-requested-with'] === 'XMLHttpRequest';
-  var auth, msg;
-  if (!token)
-    return respondWithError(res, 'missing mandatory `auth` param');
-  if (!secret)
-    return respondWithError(res, 'issuer has not configured jwt secret');
-  try {
-    auth = jwt.decode(token, secret);
-  } catch(err) {
-    return respondWithError(res, 'error decoding JWT: ' + err.message);
-  }
-  if (auth.prn !== email) {
-    msg = '`prn` mismatch: given %s, expected %s';
-    return respondWithError(res, util.format(msg, auth.prn, email));
-  }
-  return next();
+exports.auth = function auth(options) {
+  options = _.defaults(options||{}, {
+    user: true
+  });
+  return function (req, res, next) {
+    const param = req.method === "POST" ? req.body : req.query;
+    const token = param.auth;
+    const email = param.email;
+    const issuer = req.issuer;
+    const secret = issuer.jwtSecret;
+    const origin = env.origin();
+    const isXHR = req.headers['x-requested-with'] === 'XMLHttpRequest';
+    const now = Date.now()/1000|0;
+    var auth, msg;
+    if (!token)
+      return respondWithError(res, 'missing mandatory `auth` param');
+    if (!secret)
+      return respondWithError(res, 'issuer has not configured jwt secret');
+    try {
+      auth = jwt.decode(token, secret);
+    } catch(err) {
+      return respondWithError(res, 'error decoding JWT: ' + err.message);
+    }
+    if (options.user && auth.prn !== email) {
+      msg = '`prn` mismatch: given %s, expected %s';
+      return respondWithError(res, util.format(msg, auth.prn, email));
+    }
+    // If the token has an expiration, ensure that it has not passed.
+    // XXX: Should we require an expiration field? It will help prevent
+    // against unauthorized token reuse.
+    if (auth.exp && auth.exp < now) {
+      msg = 'Token has expired';
+      return respondWithError(res, msg);
+    }
+    return next();
+  };
 };
 
 function respondWithError(res, reason) {

--- a/routes/debug.js
+++ b/routes/debug.js
@@ -22,9 +22,6 @@ function flushInstances(callback) {
 exports.generateToken = function generateToken(req, res) {
   const param = req.query;
   const secret = param.secret;
-  
-  console.dir(secret);
-  
   delete param.secret;
   res.type('text').send(200, jwt.encode(param, secret));
 };

--- a/routes/debug.js
+++ b/routes/debug.js
@@ -1,6 +1,7 @@
-var async = require('async');
-var User = require('../models/user');
-var BadgeInstance = require('../models/badge-instance');
+const jwt = require('jwt-simple');
+const async = require('async');
+const User = require('../models/user');
+const BadgeInstance = require('../models/badge-instance');
 
 function removeItem(item, callback) {
   return item.remove(callback);
@@ -9,7 +10,7 @@ function removeAfterFind(callback) {
   return function (err, items) {
     if (err) return callback(err);
     return async.map(items, removeItem, callback);
-  }
+  };
 }
 function flushUsers(callback) {
   User.find(removeAfterFind(callback));
@@ -18,10 +19,20 @@ function flushInstances(callback) {
   BadgeInstance.find(removeAfterFind(callback));
 }
 
+exports.generateToken = function generateToken(req, res) {
+  const param = req.query;
+  const secret = param.secret;
+  
+  console.dir(secret);
+  
+  delete param.secret;
+  res.type('text').send(200, jwt.encode(param, secret));
+};
+
 exports.flushDb = function flushDb(req, res) {
   async.parallel([ flushUsers, flushInstances ], function (err, results) {
     console.dir(err);
     console.dir(results);
-    res.redirect(303, '/')
+    res.redirect(303, '/');
   });
 };

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -241,8 +241,25 @@ test.applyFixtures(fixtures, function () {
 
   test('Badge#getClaimCodes', function (t) {
     const badge = fixtures['offline-badge'];
-    const expect = [ 'already-claimed', 'never-claim', 'will-claim', 'remove-claim' ];
+    const expect = [
+      {code: 'already-claimed', claimed: true},
+      {code: 'never-claim', claimed: false},
+      {code: 'will-claim', claimed: false},
+      {code: 'remove-claim', claimed: false},
+    ];
+;
     t.same(badge.getClaimCodes(), expect);
+    t.end();
+  });
+  
+  test('Badge#getClaimCodes, only unclaimed', function (t) {
+    const badge = fixtures['offline-badge'];
+    const expect = [
+      {code: 'never-claim', claimed: false},
+      {code: 'will-claim', claimed: false},
+      {code: 'remove-claim', claimed: false},
+    ];
+    t.same(badge.getClaimCodes({unclaimed: true}), expect);
     t.end();
   });
 

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -11,7 +11,7 @@ test('util.slugify', function (t) {
 
 test('util.sha256', function (t) {
   var crypto = require('crypto');
-  var sum = crypto.createHash('sha256')
+  var sum = crypto.createHash('sha256');
   var expect = 'sha256$' + sum.update('awesomerad').digest('hex');
   var result = util.sha256('awesome', 'rad');
   t.same(result, expect);
@@ -49,5 +49,14 @@ test('util.toMap', function (t) {
   var obj = util.toMap(array, 'name');
   t.same(obj.ya.value, true);
   t.same(obj.nope.value, false);
+  t.end();
+});
+
+test('util.pager', function (t) {
+  var array = [0,1,2,3,4,5,6,7,8,9];
+  t.same(util.pager(array, {page: 2, count: 3}), [3,4,5]);
+  t.same(util.pager(array, {page: 4, count: 1}), [3]);
+  t.same(util.pager(array, {page: 1, count: 100}), array);
+  t.same(util.pager(array, {count: 5}), [0,1,2,3,4]);
   t.end();
 });


### PR DESCRIPTION
- Add an API endpoint for getting all of the claimcodes for a badge
- Add a debugging route for generating JWTs
- Modify `api.auth` to take options
- Allow authorization without a `prn` for protected routes that don't involve users
- Respect token `exp` if there is one.
