### PR TITLE
Add endpoints for adding, revoking badges.

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,6 +162,15 @@ app.get('/v2/user', [
   api.auth()
 ], api.user);
 
+app.delete('/v2/user/badge/:shortname', [
+  api.auth(),
+], api.removeBadge);
+
+app.post('/v2/user/badge/:shortname', [
+  api.auth(),
+  findBadgeByParamShortname,
+], api.awardBadge);
+
 app.get('/v2/badge/:shortname/claimcodes', [
   api.auth({user: false}),
   findBadgeByParamShortname,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "habitat": "0.2.2",
     "winston": "0.6.2",
     "connect-redis": "1.4.4",
-    "mongoose": "3.2.1",
+    "mongoose": "3.6.7",
     "async": "0.1.22",
     "up": "0.2.2",
     "connect-flash": "0.1.0",


### PR DESCRIPTION
- Add an endpoint for directly awarding badges
- Add an endpoint for directly revoking badges
- Update mongoose from 3.2.1 to 3.6.7
- Fix `api.auth`: flip conditional so parameters are only sought in `req.query` if method is GET. Out of the common HTTP methods, POST, PATCH, PUT and DELETE all end up sticking the parameters in `req.body`, and GET is the only one that pulls params from the query string, so we should default to using `req.body` unless the method is GET.
