### PR TITLE
[r?] Multiple issuers (backend only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ db
 /dump.rdb
 generated-codes
 .tern-port
+/notes.org

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -26,5 +26,11 @@ env.origin = function origin() {
   return env.get('origin');
 };
 
+env.isAdmin = function isAdmin(email) {
+  const admins = env.get('admins');
+  return admins.some(function (admin) {
+    return new RegExp(admin.replace('*', '.+?')).test(email);
+  });
+};
 
 module.exports = env;

--- a/models/badge-instance.js
+++ b/models/badge-instance.js
@@ -29,7 +29,7 @@ const BadgeInstanceSchema = new Schema({
   assertion: {
     type: String,
     trim: true,
-    required: true
+    required: false,
   },
   issuedOn: {
     type: Date,

--- a/models/badge-instance.js
+++ b/models/badge-instance.js
@@ -1,16 +1,16 @@
-var async = require('async');
-var db = require('./');
-var env = require('../lib/environment');
-var mongoose = require('mongoose');
-var Badge = require('./badge');
-var Schema = mongoose.Schema;
-var util = require('../lib/util');
+const async = require('async');
+const db = require('./');
+const env = require('../lib/environment');
+const mongoose = require('mongoose');
+const Badge = require('./badge');
+const Schema = mongoose.Schema;
+const util = require('../lib/util');
 
-var regex = {
+const regex = {
   email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/
-}
+};
 
-var BadgeInstanceSchema = new Schema({
+const BadgeInstanceSchema = new Schema({
   user: {
     type: String,
     required: true,
@@ -19,8 +19,7 @@ var BadgeInstanceSchema = new Schema({
   },
   badge: {
     type: String,
-    trim: true,
-    required: true
+    ref: 'Badge'
   },
   assertion: {
     type: String,
@@ -48,7 +47,7 @@ var BadgeInstanceSchema = new Schema({
     unique: true
   },
 });
-var BadgeInstance = db.model('BadgeInstance', BadgeInstanceSchema);
+const BadgeInstance = db.model('BadgeInstance', BadgeInstanceSchema);
 
 /**
  * Set the `assertion` by pulling badge by the shortname in the `badge`
@@ -79,7 +78,7 @@ BadgeInstanceSchema.pre('validate', function assertionDefault(next) {
 BadgeInstanceSchema.pre('validate', function hashDefault(next) {
   if (this.hash) return next();
   this.hash = util.hash(this.assertion);
-  next();
+  return next();
 });
 
 /**
@@ -89,7 +88,7 @@ BadgeInstanceSchema.pre('validate', function hashDefault(next) {
 BadgeInstanceSchema.pre('validate', function userBadgeKeyDefault(next) {
   if (this.userBadgeKey) return next();
   this.userBadgeKey = this.user + '.' + this.badge;
-  next();
+  return next();
 });
 
 /**

--- a/models/badge-instance.js
+++ b/models/badge-instance.js
@@ -48,7 +48,7 @@ const BadgeInstanceSchema = new Schema({
   },
   hash: {
     type: String,
-    required: true,
+    required: false,
   },
   userBadgeKey: {
     type: String,
@@ -59,7 +59,7 @@ const BadgeInstanceSchema = new Schema({
 const BadgeInstance = db.model('BadgeInstance', BadgeInstanceSchema);
 
 BadgeInstanceSchema.pre('validate', function hashDefault(next) {
-  if (this.hash) return next();
+  if (this.hash || !this.assertion) return next();
   this.hash = util.hash(this.assertion);
   return next();
 });

--- a/models/badge.js
+++ b/models/badge.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const env = require('../lib/environment');
 const util = require('../lib/util');
 const Issuer = require('./issuer');
+const BadgeInstance = require('./badge-instance');
 const phraseGenerator = require('../lib/phrases');
 const Schema = mongoose.Schema;
 
@@ -332,12 +333,12 @@ Badge.prototype.earnableBy = function earnableBy(user) {
 };
 
 Badge.prototype.award = function award(email, callback) {
-  // need to load this late to avoid circular dependency race conditions.
   const DUP_KEY_ERROR_CODE = 11000;
-  const BadgeInstance = require('./badge-instance');
   const instance = new BadgeInstance({
     user: email,
-    badge: this.shortname
+    badge: this.shortname,
+    // #TODO: fix this
+    assertion: Date.now()+'1234'+Math.random(),
   });
 
   // We don't want to fail with an error if the user already has the
@@ -396,7 +397,8 @@ Badge.prototype.imageDataURI = function imageDataURI() {
 Badge.prototype.relativeUrl = function relativeUrl(field) {
   const formats = {
     criteria: '/badge/criteria/%s',
-    image: '/badge/image/%s.png'
+    image: '/badge/image/%s.png',
+    json: '/badge/meta/%s.json'
   };
   return util.format(formats[field], this.shortname);
 };
@@ -405,4 +407,9 @@ Badge.prototype.absoluteUrl = function absoluteUrl(field) {
   return env.qualifyUrl(this.relativeUrl(field));
 };
 
+Badge.prototype.makeJson = function makeJson(opts) {
+  const root = opts.root || '';
+  const ext = opts.ext || '.json';
+
+};
 module.exports = Badge;

--- a/models/badge.js
+++ b/models/badge.js
@@ -407,9 +407,15 @@ Badge.prototype.absoluteUrl = function absoluteUrl(field) {
   return env.qualifyUrl(this.relativeUrl(field));
 };
 
-Badge.prototype.makeJson = function makeJson(opts) {
-  const root = opts.root || '';
-  const ext = opts.ext || '.json';
-
+Badge.prototype.makeJson = function makeJson() {
+  // expects a populated instance
+  return {
+    name: this.name,
+    description: this.description,
+    image: this.imageDataURI(),
+    criteria: this.absoluteUrl('criteria'),
+    issuer: this.program.absoluteUrl('json'),
+    tags: this.tags
+  };
 };
 module.exports = Badge;

--- a/models/badge.js
+++ b/models/badge.js
@@ -337,8 +337,6 @@ Badge.prototype.award = function award(email, callback) {
   const instance = new BadgeInstance({
     user: email,
     badge: this.shortname,
-    // #TODO: fix this
-    assertion: Date.now()+'1234'+Math.random(),
   });
 
   // We don't want to fail with an error if the user already has the

--- a/models/index.js
+++ b/models/index.js
@@ -1,16 +1,24 @@
-var env = require('../lib/environment');
-var mongoose = require('mongoose');
-var opts = env.get('mongo');
+const env = require('../lib/environment');
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const opts = env.get('mongo');
 
-var authOpts = {};
+const authOpts = {};
 
 if (opts.pass){
   authOpts.pass = opts.pass;
 }
-
 if (opts.user){
   authOpts.user = opts.user;
 }
-var connection = mongoose.createConnection(opts.host, opts.db, opts.port, authOpts);
+const connection = module.exports = Object.create(
+  mongoose.createConnection(opts.host, opts.db, opts.port, authOpts)
+);
+connection.generateId = generateId;
 
-module.exports = connection;
+function sha1(input) {
+  return crypto.createHash('sha1').update(input).digest('hex');
+}
+function generateId() {
+  return sha1('' + Date.now() + crypto.randomBytes(16));
+}

--- a/models/index.js
+++ b/models/index.js
@@ -2,6 +2,7 @@ const env = require('../lib/environment');
 const crypto = require('crypto');
 const mongoose = require('mongoose');
 const opts = env.get('mongo');
+const util = require('../lib/util');
 
 const authOpts = {};
 
@@ -20,5 +21,5 @@ function sha1(input) {
   return crypto.createHash('sha1').update(input).digest('hex');
 }
 function generateId() {
-  return sha1('' + Date.now() + crypto.randomBytes(16));
+  return sha1('' + Date.now() + util.randomString(16));
 }

--- a/models/issuer.js
+++ b/models/issuer.js
@@ -25,7 +25,7 @@ const regex = {
   email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/
 };
 
-const OrganizationSchema = new Schema({
+const ProgramSchema = new Schema({
   name: {
     type: String,
     trim: true,
@@ -66,7 +66,7 @@ const IssuerSchema = new Schema({
     default: generateRandomSecret
   },
   accessList: [AccessUser],
-  organizations: [OrganizationSchema]
+  programs: [ProgramSchema]
 });
 const Issuer = db.model('Issuer', IssuerSchema);
 
@@ -89,8 +89,13 @@ IssuerSchema.pre('validate', function defaultUid(next) {
   return next();
 });
 
-Issuer.prototype.addOrganization = function addOrganization(props) {
-  return this.organizations.push(props);
+Issuer.findByAccess = function findByAccess(email, callback) {
+  const query = {accessList: {'$elemMatch': {email: email }}};
+  return Issuer.find(query, callback);
+};
+
+Issuer.prototype.addProgram = function addProgram(props) {
+  return this.programs.push(props);
 };
 
 Issuer.prototype.hasAccess = function hasAccess(email) {

--- a/models/issuer.js
+++ b/models/issuer.js
@@ -99,11 +99,39 @@ Issuer.prototype.hasAccess = function hasAccess(email) {
   });
 };
 
-/**
- * Get an object compatible with the `badge.issuer` portion of the
- * OpenBadges spec.
- */
+Issuer.prototype.addAccess = function addAccess(emails) {
+  if (arguments.length > 1)
+    return this.addAccess([].slice.call(arguments));
+  if (typeof emails === 'string')
+    return this.addAccess([emails]);
 
+  emails = emails.filter(function (email) {
+    return !this.hasAccess(email);
+  }.bind(this));
+
+  if (emails.length == 0)
+    return false;
+
+  emails.forEach(function (email) {
+    this.accessList.push({email: email});
+  }.bind(this));
+
+  return true;
+};
+
+Issuer.prototype.removeAccess = function removeAccess(email) {
+  const oldList = this.accessList;
+  const newList = oldList.filter(function (acl) {
+    return acl.email !== email;
+  });
+  if (newList.length === oldList.length)
+    return false;
+  this.accessList = newList;
+  return true;
+};
+
+// TODO: change this to work with the fact that we now have the concept
+// of multiple issuers & multiple organizations for each issuer.
 Issuer.getAssertionObject = function getAssertionObject(callback) {
   Issuer.findOne(function (err, issuer) {
     if (err)

--- a/models/issuer.js
+++ b/models/issuer.js
@@ -1,13 +1,12 @@
-var db = require('./');
-var mongoose = require('mongoose');
-var env = require('../lib/environment');
-var util = require('../lib/util');
-var Schema = mongoose.Schema;
+const db = require('./');
+const mongoose = require('mongoose');
+const env = require('../lib/environment');
+const util = require('../lib/util');
+const Schema = mongoose.Schema;
 
 const DEFAULT_SECRET_LENGTH = 64;
 const NAME_MAX_LENGTH = 128;
 const ORG_MAX_LENGTH = 128;
-
 
 function generateRandomSecret() {
   return util.strongRandomString(DEFAULT_SECRET_LENGTH);
@@ -22,22 +21,37 @@ function maxLength(field, length) {
   return [lengthValidator, msg];
 }
 
-var regex = {
+const regex = {
   email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/
-}
+};
 
-var IssuerSchema = new Schema({
+const OrganizationSchema = new Schema({
+  name: {
+    type: String,
+    trim: true,
+    required: true,
+  },
+  badges: [{ type: Schema.Types.ObjectId, ref: 'Badge'}]
+});
+const AccessUser = new Schema({
+  email: {
+    type: String,
+    trim: true,
+    required: true,
+    match: regex.email
+  },
+});
+const IssuerSchema = new Schema({
   name: {
     type: String,
     trim: true,
     required: true,
     validate: maxLength('name', NAME_MAX_LENGTH)
   },
-  org: {
+  uid: {
     type: String,
     trim: true,
-    required: false,
-    validate: maxLength('org', ORG_MAX_LENGTH)
+    required: true,
   },
   contact: {
     type: String,
@@ -51,8 +65,10 @@ var IssuerSchema = new Schema({
     required: true,
     default: generateRandomSecret
   },
+  accessList: [AccessUser],
+  organizations: [OrganizationSchema]
 });
-var Issuer = db.model('Issuer', IssuerSchema);
+const Issuer = db.model('Issuer', IssuerSchema);
 
 /**
  * Set a new random secret if one is not already defined.
@@ -66,6 +82,22 @@ IssuerSchema.pre('validate', function defaultSecret(next) {
   this.jwtSecret = generateRandomSecret();
   return next();
 });
+
+IssuerSchema.pre('validate', function defaultUid(next) {
+  if (this.uid) return next();
+  this.uid = util.slugify(this.name);
+  return next();
+});
+
+Issuer.prototype.addOrganization = function addOrganization(props) {
+  return this.organizations.push(props);
+};
+
+Issuer.prototype.hasAccess = function hasAccess(email) {
+  return this.accessList.some(function (acl) {
+    return acl.email === email;
+  });
+};
 
 /**
  * Get an object compatible with the `badge.issuer` portion of the
@@ -87,5 +119,6 @@ Issuer.getAssertionObject = function getAssertionObject(callback) {
     return callback(null, result);
   });
 };
+
 
 module.exports = Issuer;

--- a/models/program.js
+++ b/models/program.js
@@ -1,0 +1,53 @@
+const db = require('./');
+const Schema = require('mongoose').Schema;
+
+const regex = {
+  email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/
+};
+
+const ProgramSchema = new Schema({
+  _id: {
+    type: String,
+    unique: true,
+    required: true,
+    default: db.generateId,
+  },
+  name: {
+    type: String,
+    trim: true,
+    required: true,
+  },
+  issuer: {
+    type: String,
+    ref: 'Issuer',
+  },
+  url: {
+    type: String,
+    trim: true,
+  },
+  description: {
+    type: String,
+    trim: true,
+  },
+  contact: {
+    type: String,
+    trim: true,
+    match: regex.email
+  },
+  badges: [{ type: Schema.Types.ObjectId, ref: 'Badge' }]
+});
+
+const Program = db.model('Program', ProgramSchema);
+module.exports = Program;
+
+
+Program.prototype.makeJson = function makeIssuerJson() {
+  const issuer = this.issuer;
+  return {
+    name: issuer.name,
+    org: this.name,
+    contact: this.contact || issuer.contact,
+    url: this.url || issuer.url,
+    description: this.description || issuer.description
+  };
+};

--- a/models/program.js
+++ b/models/program.js
@@ -1,5 +1,7 @@
 const db = require('./');
 const Schema = require('mongoose').Schema;
+const env = require('../lib/environment');
+const util = require('../lib/util');
 
 const regex = {
   email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/
@@ -42,6 +44,7 @@ module.exports = Program;
 
 
 Program.prototype.makeJson = function makeIssuerJson() {
+  // expects a populated instance
   const issuer = this.issuer;
   return {
     name: issuer.name,
@@ -50,4 +53,14 @@ Program.prototype.makeJson = function makeIssuerJson() {
     url: this.url || issuer.url,
     description: this.description || issuer.description
   };
+};
+Program.prototype.relativeUrl = function relativeUrl(field) {
+  const formats = {
+    json: '/program/meta/%s.json'
+  };
+  return util.format(formats[field], this._id);
+};
+
+Program.prototype.absoluteUrl = function absoluteUrl(field) {
+  return env.qualifyUrl(this.relativeUrl(field));
 };

--- a/models/user.js
+++ b/models/user.js
@@ -16,6 +16,7 @@ var UserSchema = new Schema({
     unique: true,
     match: regex.email
   },
+
   // `credit` is an object keyed by the shortname of a behavior with the
   // value being the amount of credit the user has for that behavior.
   // e.g., `{ 'link': 1, 'comment': 2, 'image-tag': 6 }`

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "nunjucks": "0.1.5",
     "redis": "0.8.1",
     "request": "2.11.4",
-    "habitat": "0.2.2",
+    "habitat": "0.4.2",
     "winston": "0.6.2",
     "connect-redis": "1.4.4",
     "mongoose": "3.6.7",

--- a/routes/user.js
+++ b/routes/user.js
@@ -9,7 +9,7 @@ exports.login = function login(req, res) {
   persona.verify(assertion, function (err, email) {
     if (err)
       return res.send(util.inspect(err));
-    if (!userIsAuthorized(email))
+    if (!env.isAdmin(email))
       return res.send(403, 'not authorized');
     req.session.user = email;
     return res.redirect(path);
@@ -52,14 +52,14 @@ exports.requireAuth = function requireAuth(options) {
     var user = req.session.user;
     if (isExempt(path))
       return next();
-    if (!user || !userIsAuthorized(user))
+    if (!user || !env.isAdmin(user))
       return res.redirect(options.redirectTo + '?path=' + path);
     return next();
   };
 };
 
 function getElem(key) {
-  return function (obj) { return obj[key] }
+  return function (obj) { return obj[key] };
 }
 
 exports.findAll = function findAll(options) {
@@ -85,15 +85,3 @@ exports.findAll = function findAll(options) {
     });
   };
 };
-
-function userIsAuthorized(email) {
-  var admins = env.get('admins');
-  var authorized = false;
-  admins.forEach(function (admin) {
-    if (authorized) return;
-    var adminRe = new RegExp(admin.replace('*', '.+?'));
-    if (adminRe.test(email))
-      return (authorized = true);
-  });
-  return authorized;
-}

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -3,12 +3,14 @@ const Issuer = require('../models/issuer');
 const User = require('../models/user');
 const BadgeInstance = require('../models/badge-instance');
 const Badge = require('../models/badge');
+const Program = require('../models/program');
 const test = require('./');
 
 const IMAGE = test.asset('sample.png');
 
 module.exports = {
   'issuer': new Issuer({
+    id: 'issuer',
     name: 'Badge Authority',
     contact: 'brian@example.org',
     programs: [
@@ -16,11 +18,18 @@ module.exports = {
       {name: 'Org 2'},
     ]
   }),
+  'program': new Program({
+    _id: 'program',
+    name: 'Some Program',
+    issuer: 'issuer',
+    url: 'http://example.org/program',
+  }),
   'link-basic': new Badge({
     name: 'Link Badge, basic',
     shortname: 'link-basic',
     description: 'For doing links.',
     image: IMAGE,
+    program: 'program',
     tags: ['linking', 'webdev'],
     behaviors: [
       { shortname: 'link', count: 5 }

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -21,6 +21,7 @@ module.exports = {
     shortname: 'link-basic',
     description: 'For doing links.',
     image: IMAGE,
+    tags: ['linking', 'webdev'],
     behaviors: [
       { shortname: 'link', count: 5 }
     ]

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -10,8 +10,11 @@ const IMAGE = test.asset('sample.png');
 module.exports = {
   'issuer': new Issuer({
     name: 'Badge Authority',
-    org: 'Some Org',
-    contact: 'brian@example.org'
+    contact: 'brian@example.org',
+    programs: [
+      {name: 'Org 1'},
+      {name: 'Org 2'},
+    ]
   }),
   'link-basic': new Badge({
     name: 'Link Badge, basic',
@@ -92,4 +95,3 @@ module.exports = {
     seen: true
   })
 };
-

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -17,6 +17,29 @@ function validBadge() {
 
 var fixtures = require('./badge-model.fixtures.js');
 test.applyFixtures(fixtures, function () {
+
+  test('Badge#makeJson', function (t) {
+    env.temp({origin: 'https://example.org'}, function (done) {
+      const program = fixtures['program'];
+      const badge = fixtures['link-basic'];
+
+      badge.populate('program', function () {
+        const expect = {
+          name: badge.name,
+          description: badge.description,
+          image: badge.imageDataURI(),
+          criteria: badge.absoluteUrl('criteria'),
+          issuer: program.absoluteUrl('json'),
+          tags: badge.tags
+        };
+        t.same(badge.makeJson(), expect);
+        t.end();
+        done();
+      });
+    });
+  });
+
+
   test('Badge#imageDataURI', function (t) {
     var badge = new Badge({image: test.asset('sample.png')});
     var dataURI = badge.imageDataURI();

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -119,7 +119,7 @@ test.applyFixtures(fixtures, function () {
 
   test('Badge#earnableBy: not enough', function (t) {
     var badge = fixtures['link-comment'];
-    var user = { credit: { link: 10 }}
+    var user = { credit: { link: 10 }};
     var expect = false;
     var result = badge.earnableBy(user);
     t.same(expect, result);
@@ -143,7 +143,7 @@ test.applyFixtures(fixtures, function () {
 
   test('Badge#creditsUntilAward: see how many credits remain until user gets badge', function (t) {
     var badge = fixtures['link-comment'];
-    var user = { credit: { link: 26 }}
+    var user = { credit: { link: 26 }};
     var expect = { comment: 5 };
     var result = badge.creditsUntilAward(user);
     t.same(result, expect);
@@ -154,7 +154,7 @@ test.applyFixtures(fixtures, function () {
     var badge = new Badge({
       name: 'An   awesome badge!',
       description: 'some sorta badge',
-    })
+    });
     badge.save(function (err, result) {
       t.same(badge.shortname, 'an-awesome-badge', 'should slugify if shortname is not provided');
       t.end();
@@ -192,42 +192,6 @@ test.applyFixtures(fixtures, function () {
     t.same(badge.behaviors.length, 1, 'should have one left');
     t.same(badge.behaviors[0].shortname, 'comment', 'should be the comment one');
     t.end();
-  });
-
-  test('Badge#makeAssertion: makes a good assertion', function (t) {
-    var tempenv = { protocol: 'http', host: 'example.org', port: 80 };
-    env.temp(tempenv, function (resetEnv) {
-      var badge = fixtures['comment'];
-      var issuer = fixtures['issuer'];
-      var recipient = 'brian@example.org';
-      var salt = 'salt';
-      var expect = {
-        recipient: util.sha256(recipient, salt),
-        salt: salt,
-        badge: {
-          version: '0.5.0',
-          criteria: badge.absoluteUrl('criteria'),
-          image: badge.absoluteUrl('image'),
-          description: badge.description,
-          name: badge.name,
-          issuer: {
-            name: issuer.name,
-            contact: issuer.contact,
-            origin: env.origin()
-          }
-        }
-      };
-      badge.makeAssertion({
-        recipient: recipient,
-        salt: salt,
-      }, {
-        json: false
-      }, function (err, result) {
-        t.same(result, expect);
-        resetEnv();
-        t.end();
-      });
-    });
   });
 
   test('Badge#hasClaimCode', function (t) {

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -40,7 +40,7 @@ test.applyFixtures(fixtures, function () {
   test('Badge#validate: image too big', function (t) {
     var errorKeys;
     var badge = validBadge();
-    var length = 257 * 1024
+    var length = 257 * 1024;
     badge.image = Buffer(length);
     badge.validate(function (err) {
       t.ok(err, 'should have errors');
@@ -212,7 +212,6 @@ test.applyFixtures(fixtures, function () {
           name: badge.name,
           issuer: {
             name: issuer.name,
-            org: issuer.org,
             contact: issuer.contact,
             origin: env.origin()
           }
@@ -251,7 +250,7 @@ test.applyFixtures(fixtures, function () {
     t.same(badge.getClaimCodes(), expect);
     t.end();
   });
-  
+
   test('Badge#getClaimCodes, only unclaimed', function (t) {
     const badge = fixtures['offline-badge'];
     const expect = [

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -2,7 +2,8 @@ var test = require('./');
 var env = require('../lib/environment');
 
 env.temp({
-  origin: 'https://example.org:443'
+  origin: 'https://example.org:443',
+  admins: ['*@example.org', 'brian@mozillafoundation.org'],
 }, function (reset) {
 
   test('env.qualifyUrl', function (t) {
@@ -16,6 +17,14 @@ env.temp({
     var expect = 'https://example.org:443';
     var result = env.origin();;
     t.same(result, expect);
+    t.end();
+  });
+
+  test('env.isAdmin', function (t) {
+    t.same(env.isAdmin('brian@example.org'), true);
+    t.same(env.isAdmin('anyone@example.org'), true);
+    t.same(env.isAdmin('guy@bad-domain.org'), false);
+    t.same(env.isAdmin('brian@mozillafoundation.org'), true);
     t.end();
   });
 });

--- a/tests/index.js
+++ b/tests/index.js
@@ -89,7 +89,7 @@ test.applyFixtures = function applyFixtures(fixtures, carryOn) {
     async.map(models(fixtures), flush, function (err, results) {
       if (err) throw err;
       callback(results);
-    })
+    });
   }
 
   /**
@@ -101,7 +101,7 @@ test.applyFixtures = function applyFixtures(fixtures, carryOn) {
     }
     async.map(values(fixtures), saver, function (err, results) {
       if (err) throw err;
-      callback(null, results)
+      callback(null, results);
     });
   }
 

--- a/tests/issuer-model.test.js
+++ b/tests/issuer-model.test.js
@@ -15,7 +15,23 @@ test.applyFixtures({
   'testIssuer': new Issuer({
     name: 'Mozilla',
     contact: 'brian@mozillafoundation.org',
-  })
+  }),
+  'issuer1': new Issuer({
+    name: 'Issuer One',
+    contact: 'one@example.org',
+    accessList: [
+      {email: 'both@example.org'},
+      {email: 'one@example.org'},
+    ],
+  }),
+  'issuer2': new Issuer({
+    name: 'Issuer Two',
+    contact: 'two@example.org',
+    accessList: [
+      {email: 'both@example.org'},
+      {email: 'two@example.org'},
+    ],
+  }),
 }, function (fixtures) {
   test('Issuer#validate: everything is cool', function (t) {
     const issuer = validIssuer();
@@ -35,13 +51,13 @@ test.applyFixtures({
     });
   });
 
-  test('Issuer#addOrganization', function (t) {
+  test('Issuer#addProgram', function (t) {
     const issuer = fixtures['testIssuer'];
-    const orgs = ['Webmaker', 'Engagement', 'WebDev'].sort();
-    orgs.forEach(function (o) {issuer.addOrganization({name: o})});
+    const programs = ['Webmaker', 'Engagement', 'WebDev'].sort();
+    programs.forEach(function (o) {issuer.addProgram({name: o})});
     issuer.save(function (err, result) {
-      const orgNames = _.pluck(result.organizations, 'name').sort();
-      t.same(orgNames, orgs);
+      const orgNames = _.pluck(result.programs, 'name').sort();
+      t.same(orgNames, programs);
       t.end();
     });
   });
@@ -83,18 +99,17 @@ test.applyFixtures({
     t.end();
   });
 
-  test('Issuer.getAssertionObject', function (t) {
-    env.temp({ origin: 'http://example.org' }, function (resetEnv) {
-      const expect = {
-        name: 'Mozilla',
-        contact: 'brian@mozillafoundation.org',
-        origin: 'http://example.org',
-      };
-      Issuer.getAssertionObject(function (err, result) {
-        t.same(result, expect);
-        resetEnv();
-        t.end();
-      });
+  test('Issuer.findByAccess', function (t) {
+    t.plan(3);
+    Issuer.findByAccess('one@example.org', function (err, results) {
+      t.same(fixtures['issuer1'].name, results[0].name);
+    });
+    Issuer.findByAccess('two@example.org', function (err, results) {
+      t.same(fixtures['issuer2'].name, results[0].name);
+    });
+    Issuer.findByAccess('both@example.org', function (err, results) {
+      const names = results.map(function (o) { return o.name }).sort();
+      t.same(names, ['Issuer One', 'Issuer Two']);
     });
   });
 

--- a/tests/issuer-model.test.js
+++ b/tests/issuer-model.test.js
@@ -15,10 +15,6 @@ test.applyFixtures({
   'testIssuer': new Issuer({
     name: 'Mozilla',
     contact: 'brian@mozillafoundation.org',
-    accessList: [
-      {email: 'one@example.org'},
-      {email: 'two@example.org'}
-    ],
   })
 }, function (fixtures) {
   test('Issuer#validate: everything is cool', function (t) {
@@ -51,9 +47,39 @@ test.applyFixtures({
   });
 
   test('Issuer#hasAccess', function (t) {
-    const issuer = fixtures['testIssuer'];
+    const issuer = new Issuer({
+      accessList: [
+        {email: 'one@example.org'},
+        {email: 'two@example.org'},
+      ]
+    });
+    t.same(issuer.hasAccess('one@example.org'), true);
     t.same(issuer.hasAccess('two@example.org'), true);
     t.same(issuer.hasAccess('three@example.org'), false);
+    t.end();
+  });
+
+  test('Issuer#removeAccess', function (t) {
+    const issuer = new Issuer({
+      accessList: [{email: 'remove-me@example.org'}],
+    });
+    t.same(issuer.hasAccess('remove-me@example.org'), true);
+    t.same(issuer.removeAccess('remove-me@example.org'), true);
+    t.same(issuer.hasAccess('remove-me@example.org'), false);
+    t.end();
+  });
+
+  test('Issuer#addAccess', function (t) {
+    const issuer = new Issuer();
+    issuer.addAccess('test1@example.org');
+    issuer.addAccess('test1@example.org');
+    issuer.addAccess('test1@example.org');
+    issuer.addAccess(['test2@example.org', 'test3@example.org']);
+    issuer.addAccess('test4@example.org', 'test5@example.org');
+
+    [1,2,3,4,5].forEach(function (n) {
+      t.same(issuer.hasAccess('test'+n+'@example.org'), true);
+    });
     t.end();
   });
 

--- a/tests/program-model.test.js
+++ b/tests/program-model.test.js
@@ -1,0 +1,55 @@
+const test = require('./');
+const db = require('../models');
+const Issuer = require('../models/issuer');
+const Program = require('../models/program');
+
+test.applyFixtures({
+  'issuer': new Issuer({
+    _id: 'issuer1',
+    uid: 'example-org',
+    name: 'Example.org',
+    contact: 'a@example.org',
+    url: 'https://example.org',
+    description: 'Example Issuer'
+  }),
+  'program': new Program({
+    _id: 'program1',
+    name: 'Sample Program',
+    issuer: 'issuer1',
+    url: 'https://example.org/program',
+  }),
+}, function (fixtures) {
+
+  test('Finding a program and an issuer', function (t) {
+    const program = fixtures['program'];
+    const issuer = fixtures['issuer'];
+    Program.findOne({'_id': program._id})
+      .populate('issuer')
+      .exec(function (err, result) {
+        t.same(result.issuer._id, issuer._id);
+        t.end();
+      });
+  });
+
+  test('Generating issuer json', function (t) {
+    const issuer = fixtures['issuer'];
+    const program = fixtures['program'];
+    const expect =  {
+      name: issuer.name,
+      org: program.name,
+      contact: program.contact || issuer.contact,
+      url: program.url || issuer.url,
+      description: program.description || issuer.description
+    };
+
+    program.populate('issuer', function () {
+      t.same(program.makeJson(), expect);
+      t.end();
+    });
+  });
+
+
+  test('shutting down #', function (t) {
+    db.close(); t.end();
+  });
+});

--- a/tests/user-model.test.js
+++ b/tests/user-model.test.js
@@ -62,7 +62,7 @@ test.applyFixtures({
     var email = expect.user;
     User.credit(email, ['link', 'comment'], function (err, result, awarded, inProgress) {
       t.notOk(err, 'should not have an error');
-      t.same(result.credit.link, expect.credit.link + 1)
+      t.same(result.credit.link, expect.credit.link + 1);
       t.same(result.credit.comment, 1);
 
       t.same(awarded.length, 1);


### PR DESCRIPTION
Lots of changes to make multiple issuers with multiple programs work:
- Use a custom `_id` type for most models to make testing relationships easier
- Issuers can have Programs
- Programs can have badges.
- Badges can be associated with programs (the above relationship is both ways)
- Use the 1.0 assertion specification
- Issuers also have a new field, `accessList`, which is related to letting a list of users sign in to issue badges
- Remove a lot of dead/extraneous comments

Note, this does NOT include the necessary frontend changes for the feature; this is backend only.

@toolness, @stenington to review
