### PR TITLE
Implement `doNotList` attribute on badges

### DIFF
--- a/models/badge.js
+++ b/models/badge.js
@@ -64,6 +64,10 @@ const BadgeSchema = new Schema({
     type: String,
     ref: 'Program',
   },
+  doNotList: {
+    type: Boolean,
+    default: false,
+  },
   tags: [String],
   name: {
     type: String,

--- a/routes/api.js
+++ b/routes/api.js
@@ -18,10 +18,9 @@ exports.badges = function badges(req, res) {
   Badge.find(function (err, badges) {
     if (err)
       return res.send(500, { status: 'error', error: err });
-    badges = badges.filter(function (badge) {
-      return badge.claimCodes.length === 0;
-    });
-    badges.forEach(function (badge) {
+    badges.filter(function (badge) {
+      return !badge.doNotList;
+    }).forEach(function (badge) {
       result.badges[badge.shortname] = {
         name: badge.name,
         description: badge.description,

--- a/views/admin/create-or-edit-badge.html
+++ b/views/admin/create-or-edit-badge.html
@@ -80,6 +80,18 @@
     </div>
 
     <div>
+      <label>
+        List in APIs?
+        <input name="list" type="checkbox" {% if badge.doNotList == false %}checked{% endif %}>
+      </label>
+      <span class="help-block">
+        Whether or not this badge should be shown when an API call is
+        made to list all of the badges. In most cases, this should be
+        left checked.
+      </span>
+    </div>
+
+    <div>
       <label for="image">New Image</label>
       <input
           type="file"

--- a/views/admin/show-badge.html
+++ b/views/admin/show-badge.html
@@ -31,6 +31,9 @@
       <dt>Description</dt>
       <dd>{{ badge.description | stupidSafe }}</dd>
 
+      <dt>List in APIs?</dt>
+      <dd>{{ badge.doNotList }}</dd>
+
       <br style="clear: both">
       <dt>Criteria (<a href="/badge/criteria/{{ badge.shortname }}">Preview</a>)</dt>
       <dd><textarea class="badge-criteria" disabled>{{ badge.criteria.content }}</textarea></dd>


### PR DESCRIPTION
closes #77 (https://github.com/mozilla/openbadger/issues/77)

There are some cases where we don't want to list a badge as part of an
API response. This changeset provides the backend attribute and the
frontend for managing that attribute.
