### PR TITLE
Parse rubric information from criteria and provide it via the API

### DIFF
--- a/models/badge.js
+++ b/models/badge.js
@@ -518,8 +518,9 @@ Badge.parseRubricItems = function(content) {
 };
 
 Badge.prototype.getRubricItems = function() {
-  var source = this.criteria.content;
-  return Badge.parseRubricItems(this.criteria.content);
+  return this.criteria.content
+         ? Badge.parseRubricItems(this.criteria.content)
+         : [];
 };
 
 Badge.prototype.getRecommendations = function (email, callback) {

--- a/models/badge.js
+++ b/models/badge.js
@@ -495,6 +495,33 @@ Badge.prototype.makeJson = function makeJson() {
   };
 };
 
+Badge.parseRubricItems = function(content) {
+  const OPTIONAL_REGEXP = /\(\s*optional\s*\)/;
+  var lines = content.split('\n');
+  var rubricItems = [];
+
+  lines.forEach(function(line) {
+    line = line.trim();
+    if (line.length && line[0] == '*') {
+      rubricItems.push({
+        text: line.slice(1).trim(),
+        required: !OPTIONAL_REGEXP.test(line)
+      });
+    }
+  });
+  if (rubricItems.length == 0)
+    rubricItems.push({
+      text: "Satisfies the following criteria:\n" + content,
+      required: true
+    });
+  return rubricItems;
+};
+
+Badge.prototype.getRubricItems = function() {
+  var source = this.criteria.content;
+  return Badge.parseRubricItems(this.criteria.content);
+};
+
 Badge.prototype.getRecommendations = function (email, callback) {
   if (typeof email == 'function')
     callback = email, email = null;

--- a/routes/api.js
+++ b/routes/api.js
@@ -16,6 +16,9 @@ function normalize(badge) {
     description: badge.description,
     prerequisites: badge.prerequisites,
     image: badge.absoluteUrl('image'),
+    rubric: {
+      items: badge.getRubricItems()
+    },
     behaviors: badge.behaviors.map(function (behavior) {
       return { name: behavior.shortname, score: behavior.count };
     })
@@ -44,7 +47,7 @@ exports.badges = function badges(req, res) {
 
 
 exports.badge = function badge(req, res) {
-  res.json({ status: 'ok', badge: normalize(req.badge) });
+  res.json(200, { status: 'ok', badge: normalize(req.badge) });
 };
 
 exports.recommendations = function recommendations(req, res, next) {

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -105,6 +105,15 @@ module.exports = {
     image: IMAGE,
     claimCodes: []
   }),
+  'with-criteria': new Badge({
+    name: 'Badge with criteria',
+    shortname: 'with-criteria',
+    description: 'For doing random stuff',
+    criteria: {
+      content: "* person is awesome"
+    },
+    image: IMAGE,
+  }),
   'user': new User({
     user: 'brian@example.org',
     credit: {}

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -17,6 +17,51 @@ function validBadge() {
 
 var fixtures = require('./badge-model.fixtures.js');
 test.applyFixtures(fixtures, function () {
+  test('Badge.parseRubricItems() works w/ bulleted lists', function(t) {
+    var criteria = [
+      '* lol',
+      '* oof (optional)',
+      'hi'
+    ].join('\n');
+
+    t.same(Badge.parseRubricItems(criteria), [
+      {
+        text: 'lol',
+        required: true
+      },
+      {
+        text: 'oof (optional)',
+        required: false
+      }
+    ]);
+    t.end();
+  });
+
+  test('Badge.parseRubricItems() works w/o bulleted lists', function(t) {
+    var criteria = [
+      'hi',
+      'there',
+      'dood'
+    ].join('\n');
+
+    t.same(Badge.parseRubricItems(criteria), [
+      {
+        text: 'Satisfies the following criteria:\nhi\nthere\ndood',
+        required: true
+      }
+    ]);
+    t.end();
+  });
+
+  test('Badge#getRubricItems', function(t) {
+    t.same(fixtures['with-criteria'].getRubricItems(), [
+      {
+        text: 'person is awesome',
+        required: true
+      }
+    ]);
+    t.end();
+  });
 
   test('Badge#makeJson', function (t) {
     env.temp({origin: 'https://example.org'}, function (done) {

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -53,13 +53,18 @@ test.applyFixtures(fixtures, function () {
     t.end();
   });
 
-  test('Badge#getRubricItems', function(t) {
+  test('Badge#getRubricItems works w/ criteria', function(t) {
     t.same(fixtures['with-criteria'].getRubricItems(), [
       {
         text: 'person is awesome',
         required: true
       }
     ]);
+    t.end();
+  });
+
+  test('Badge#getRubricItems works w/o criteria', function(t) {
+    t.same(fixtures['random-badge'].getRubricItems(), []);
     t.end();
   });
 


### PR DESCRIPTION
This fixes #120.

All API endpoints that return badge objects now include a `rubric` key, which corresponds to Aestimia's rubric for rubrics, i.e. it's an object containing an `items` array, which contains objects that have `text` containing string content, and `required` which is a boolean.
