### PR TITLE
Push badge class info down in /user endpoint as well

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -182,8 +182,10 @@ exports.user = function user(req, res) {
         assertionUrl: instance.absoluteUrl('assertion'),
         isRead: instance.seen,
         issuedOn: instance.issuedOnUnix(),
-        name: instance.badge.name,
-        image: instance.badge.absoluteUrl('image')
+        badgeClass: {
+          name: instance.badge.name,
+          image: instance.badge.absoluteUrl('image')
+        }
       };
     });
 


### PR DESCRIPTION
Related to #159, the `/v2/user` endpoint should probably match the `/v2/user/badge/:shortname` endpoint in putting badge class information into a `badgeClass` attribute.
