### PR TITLE
User badge recommendations, stage 2

### DIFF
--- a/models/badge.js
+++ b/models/badge.js
@@ -617,26 +617,23 @@ Badge.getRecommendations = function (opts, callback) {
 
         // We want to have something to recommend, so we check to see if
         // we've filtered out everything and if we have, resort to
-        // shuffling up all the badges and use that.
+        // shuffling up all the badges and use that. Also, for the API
+        // endpoint we need to have fully populated badge classes,
+        // including program and issuer, so we filter out any badges
+        // that don't have an issuer associated with its program.
         const result = (filtered.length
                         ? filtered
                         : _.shuffle(allBadges))
           .sort(onlineBias)
-          .filter(prop('program'))
+          .filter(prop('program', 'issuer'))
           .slice(0, limit);
 
-        // For the API endpoint we need to have fully populated badge
-        // classes, including program and issuer, so we want to filter
-        // out any badges that aren't associated with programs, then any
-        // badges that have programs that aren't associated with issuers
         return async.map(
           result.map(prop('program')),
           method('populate', 'issuer'),
           function (err) {
             if (err) return callback(err);
-            return callback(
-              null, result.filter(prop('program', 'issuer'))
-            );
+            return callback(null, result);
           }
         );
 

--- a/models/badge.js
+++ b/models/badge.js
@@ -550,6 +550,7 @@ function isProgramActive(program) {
 Badge.getRecommendations = function (opts, callback) {
   const prop = util.prop;
   const method = util.method;
+
   const email = opts.email;
   const limit = opts.limit || Infinity;
   const userAgeRange = opts.ageRange;
@@ -580,9 +581,9 @@ Badge.getRecommendations = function (opts, callback) {
         .uniq()
         .value();
 
-      const earnedCategoryLevel = instances
-        .filter(util.prop('badge', 'categoryAward'))
-        .map(util.prop('badge', 'categoryAward'));
+      const completedCategories = instances
+        .filter(prop('badge', 'categoryAward'))
+        .map(prop('badge', 'categoryAward'));
 
       const query = {_id: { '$nin': earnedBadgeIds }};
 
@@ -601,7 +602,7 @@ Badge.getRecommendations = function (opts, callback) {
             const noParticipation = b.type !== 'participation';
             const noCategoryBadges = !b.categoryAward;
             const noneFromEarnedCategories =
-              !_.intersection(b.categories, earnedCategoryLevel).length;
+              !_.intersection(b.categories, completedCategories).length;
             const onlyOnTrack =
               _.intersection(b.categories, onTrackCategories).length;
             return (true
@@ -614,6 +615,9 @@ Badge.getRecommendations = function (opts, callback) {
                    );
           });
 
+        // We want to have something to recommend, so we check to see if
+        // we've filtered out everything and if we have, resort to
+        // shuffling up all the badges and use that.
         const result = (filtered.length
                         ? filtered
                         : _.shuffle(allBadges))

--- a/models/badge.js
+++ b/models/badge.js
@@ -629,8 +629,9 @@ Badge.getRecommendations = function (opts, callback) {
           result.map(prop('program')),
           method('populate', 'issuer'),
           function (err) {
+            if (err) return callback(err);
             return callback(
-              err, (err ? null : result.filter(prop('issuer')))
+              null, result.filter(prop('program', 'issuer'))
             );
           }
         );

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -27,6 +27,7 @@ module.exports = {
   }),
   'link-basic': new Badge({
     _id: 'bba3989d4825d81b5587f96b7d8ba6941d590fff',
+    program: 'program',
     name: 'Link Badge, basic',
     shortname: 'link-basic',
     description: 'For doing links.',
@@ -38,6 +39,7 @@ module.exports = {
     ]
   }),
   'link-advanced': new Badge({
+    program: 'program',
     name : 'Link Badge, advanced',
     shortname: 'link-advanced',
     description: 'For doing lots of links.',
@@ -47,6 +49,7 @@ module.exports = {
     ]
   }),
   'comment': new Badge({
+    program: 'program',
     name : 'Commenting badge',
     shortname: 'comment',
     description: 'For doing lots of comments.',
@@ -56,6 +59,7 @@ module.exports = {
     ]
   }),
   'link-comment': new Badge({
+    program: 'program',
     name : 'Linking and commenting badge',
     shortname: 'link-comment',
     description: 'For doing lots of comments and links',
@@ -66,6 +70,7 @@ module.exports = {
     ]
   }),
   'offline-badge': new Badge({
+    program: 'program',
     name: 'Offline badge',
     shortname: 'offline-badge',
     description: 'For doing stuff offline',
@@ -79,6 +84,7 @@ module.exports = {
     ]
   }),
   'multi-claim-badge': new Badge({
+    program: 'program',
     name: 'Multi claim badge',
     shortname: 'multi-claim-badge',
     description: 'Multi',
@@ -91,6 +97,7 @@ module.exports = {
     ]
   }),
   'other-offline-badge': new Badge({
+    program: 'program',
     name: 'Other Offline badge',
     shortname: 'other-offline-badge',
     description: 'For doing more offline stuff',
@@ -102,6 +109,7 @@ module.exports = {
     ]
   }),
   'random-badge': new Badge({
+    program: 'program',
     name: 'Random code badge',
     shortname: 'random-badge',
     description: 'For doing random stuff',
@@ -109,6 +117,7 @@ module.exports = {
     claimCodes: []
   }),
   'with-criteria': new Badge({
+    program: 'program',
     name: 'Badge with criteria',
     shortname: 'with-criteria',
     description: 'For doing random stuff',
@@ -128,20 +137,24 @@ module.exports = {
     seen: true
   }),
   'science1': new Badge({
+    program: 'program',
     name: 'science1',
     shortname: 'science1',
     description: 'science1',
     image: IMAGE,
-    categories: ['science']
+    categories: ['science'],
   }),
   'science2': new Badge({
+    program: 'program',
     name: 'science2',
     shortname: 'science2',
     description: 'science2',
     image: IMAGE,
-    categories: ['science']
+    categories: ['science'],
+    program: '',
   }),
   'science3': new Badge({
+    program: 'program',
     name: 'science3',
     shortname: 'science3',
     description: 'science3',
@@ -149,6 +162,7 @@ module.exports = {
     categories: ['science']
   }),
   'science-math1': new Badge({
+    program: 'program',
     name: 'science-math1',
     shortname: 'science-math1',
     description: 'science-math1',
@@ -156,6 +170,7 @@ module.exports = {
     categories: ['science', 'math']
   }),
   'science-math2': new Badge({
+    program: 'program',
     name: 'science-math2',
     shortname: 'science-math2',
     description: 'science-math2',
@@ -163,6 +178,7 @@ module.exports = {
     categories: ['science', 'math']
   }),
   'science-math3': new Badge({
+    program: 'program',
     name: 'science-math3',
     shortname: 'science-math3',
     description: 'science-math3',

--- a/tests/badge-recommendations.test.js
+++ b/tests/badge-recommendations.test.js
@@ -200,6 +200,8 @@ test.applyFixtures({
               'should contain pure-science badge');
       t.equal(contains(names, 'adult-science'), true,
               'should contain adult-science badge');
+      t.equal(lastElem(names), 'offline-science',
+              'should recommend offline badges last');
       console.dir(names);
       t.end();
     });
@@ -214,9 +216,13 @@ test.applyFixtures({
 
 const prop = util.prop;
 
+function lastElem(arr) {
+  return arr[arr.length-1];
+}
+
 function contains(arr, name) {
   return arr.some(has(name));
-};
+}
 
 function has(name) {
   return function (n) {

--- a/tests/badge-recommendations.test.js
+++ b/tests/badge-recommendations.test.js
@@ -101,7 +101,7 @@ test.applyFixtures({
     type: 'skill',
     activityType: 'online',
     categoryAward: '',
-    ageRange: ['18-24'],
+    ageRange: ['19-24'],
     image: Buffer(1),
   }),
   'pure-knitting': new Badge({

--- a/tests/badge-recommendations.test.js
+++ b/tests/badge-recommendations.test.js
@@ -5,6 +5,7 @@ const User = require('../models/user');
 const Badge = require('../models/badge');
 const BadgeInstance = require('../models/badge-instance');
 const Program = require('../models/program');
+const Issuer = require('../models/issuer');
 const util = require('../lib/util');
 
 const TESTUSER = 'brian@example.org';
@@ -20,16 +21,25 @@ function createBadge(id, obj) {
     activityType: 'online',
     ageRange: ALL_AGES,
     image: Buffer(1),
-    program: '',
+    program: 'in-progress',
     categoryAward: '',
     type: 'skill',
   }));
 }
 
 test.applyFixtures({
+  // Issuer
+  'issuer': new Issuer({
+    _id: 'issuer',
+    shortname: 'issuer',
+    name: 'Issuer',
+    programs: ['not-yet', 'in-progress', 'ended']
+  }),
+
   // Programs
   'not-yet-program': new Program({
     _id: 'not-yet',
+    issuer: 'issuer',
     shortname: 'not-yet',
     startDate: new Date('2013-06-15'),
     endDate: new Date('2013-07-15'),
@@ -37,6 +47,7 @@ test.applyFixtures({
   }),
   'in-progress-program': new Program({
     _id: 'in-progress',
+    issuer: 'issuer',
     shortname: 'in-progress',
     startDate: new Date('2013-06-01'),
     endDate: new Date('2013-07-15'),
@@ -44,6 +55,7 @@ test.applyFixtures({
   }),
   'ended-program': new Program({
     _id: 'ended',
+    issuer: 'issuer',
     shortname: 'ended',
     startDate: new Date('2013-05-15'),
     endDate: new Date('2013-06-01'),
@@ -151,6 +163,9 @@ test.applyFixtures({
       ageRange: Badge.ADULT
     }, function (err, badges) {
       const names = badges.map(prop('shortname'));
+
+      t.same(badges[0].program.issuer._id, fx['issuer']._id,
+             'should have populated issuer');
 
       // misc
       t.equal(contains(names, 'pure-science'), true,

--- a/tests/badge-recommendations.test.js
+++ b/tests/badge-recommendations.test.js
@@ -1,145 +1,116 @@
+const _ = require('underscore');
 const test = require('./');
 const db = require('../models');
 const User = require('../models/user');
 const Badge = require('../models/badge');
 const BadgeInstance = require('../models/badge-instance');
+const Program = require('../models/program');
 const util = require('../lib/util');
 
 const TESTUSER = 'brian@example.org';
 const ALL_AGES = [Badge.KID, Badge.TEEN, Badge.ADULT];
+const TODAY = new Date('2013-06-03');
+
+function createBadge(id, obj) {
+  return new Badge(_.defaults(obj, {
+    _id: id,
+    shortname: id,
+    name: 'badge',
+    description: 'desc',
+    activityType: 'online',
+    ageRange: ALL_AGES,
+    image: Buffer(1),
+    program: '',
+    categoryAward: '',
+    type: 'skill',
+  }));
+}
 
 test.applyFixtures({
-  'city-science': new Badge({
-    shortname: 'city-science',
+  // Programs
+  'not-yet-program': new Program({
+    _id: 'not-yet',
+    shortname: 'not-yet',
+    startDate: new Date('2013-06-15'),
+    endDate: new Date('2013-07-15'),
+    name: 'Not Yet',
+  }),
+  'in-progress-program': new Program({
+    _id: 'in-progress',
+    shortname: 'in-progress',
+    startDate: new Date('2013-06-01'),
+    endDate: new Date('2013-07-15'),
+    name: 'In Progress',
+  }),
+  'ended-program': new Program({
+    _id: 'ended',
+    shortname: 'ended',
+    startDate: new Date('2013-05-15'),
+    endDate: new Date('2013-06-01'),
+    name: 'Ended',
+  }),
+
+  // Badges
+  'not-yet-science': createBadge('not-yet-science', {
     categories: ['science'],
-    name: 'City Science Badge',
-    description: 'For earning a bunch of science badges',
+    program: 'not-yet',
+  }),
+  'ended-science': createBadge('ended-science', {
+    categories: ['science'],
+    program: 'ended',
+  }),
+  'in-progress-science': createBadge('in-progress-science', {
+    categories: ['science'],
+    program: 'in-progress',
+  }),
+  'city-science': createBadge('city-science', {
+    categories: ['science'],
     categoryAward: 'science',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'city-math': new Badge({
-    _id: 'city-math',
-    shortname: 'city-math',
+  'city-math': createBadge('city-math', {
     categories: ['math'],
-    name: 'City Math Badge',
-    description: 'For earning a bunch of math badges',
     categoryAward: 'math',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'participation-science': new Badge({
-    shortname: 'participation-science',
-    categories: ['science'],
-    name: 'Participation Science Badge',
-    description: 'For participating in science',
+  'participation-science': createBadge('participation-science', {
     type: 'participation',
-    activityType: 'online',
-    categoryAward: '',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
-  }),
-  'offline-science': new Badge({
-    shortname: 'offline-science',
     categories: ['science'],
-    name: 'Offline Science Badge',
-    description: 'For participating in offline science',
-    type: 'achievement',
+  }),
+  'offline-science': createBadge('offline-science', {
+    categories: ['science'],
     activityType: 'offline',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'pure-science': new Badge({
-    shortname: 'pure-science',
+  'pure-science': createBadge('pure-science', {
     categories: ['science'],
-    name: 'Pure Science',
-    description: 'for sciencing',
-    type: 'skill',
-    activityType: 'online',
-    categoryAward: '',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'pure-math': new Badge({
-    shortname: 'pure-math',
+  'pure-math': createBadge('pure-math', {
     categories: ['math'],
-    name: 'Math',
-    description: 'for mathing',
-    type: 'skill',
-    activityType: 'online',
-    categoryAward: '',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'kid-science': new Badge({
-    shortname: 'kid-science',
+  'kid-science': createBadge('kid-science', {
     categories: ['science'],
-    name: 'Kid Science',
-    description: 'for sciencing (for kids)',
-    type: 'skill',
-    activityType: 'online',
-    categoryAward: '',
     ageRange: ['0-13'],
-    image: Buffer(1),
   }),
-  'teen-science': new Badge({
-    shortname: 'teen-science',
+  'teen-science': createBadge('teen-science', {
     categories: ['science'],
-    name: 'Teen Science',
-    description: 'for sciencing (for teens)',
-    type: 'skill',
-    activityType: 'online',
-    categoryAward: '',
     ageRange: ['13-18'],
-    image: Buffer(1),
   }),
-  'adult-science': new Badge({
-    shortname: 'adult-science',
+  'adult-science': createBadge('adult-science', {
     categories: ['science'],
-    name: 'Adult Science',
-    description: 'for sciencing (for teens)',
-    type: 'skill',
-    activityType: 'online',
-    categoryAward: '',
     ageRange: ['19-24'],
-    image: Buffer(1),
   }),
-  'pure-knitting': new Badge({
-    shortname: 'pure-knitting',
+  'pure-knitting': createBadge('pure-knitting', {
     categories: ['knitting'],
-    name: 'Knitting',
-    description: 'for knitting',
-    type: 'skill',
-    activityType: 'online',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'science-and-math': new Badge({
-    shortname: 'science-and-math',
+  'science-and-math': createBadge('science-and-math', {
     categories: ['science', 'math'],
-    name: 'Science and Math',
-    type: 'skill',
-    activityType: 'online',
-    description: 'for sciencing and mathing',
-    categoryAward: '',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
-  'earned-badge': new Badge({
-    _id: '1234',
-    shortname: 'earned',
+  'earned-badge': createBadge('earned', {
     categories: ['science', 'math'],
-    name: 'Earned',
-    type: 'skill',
-    activityType: 'online',
-    description: 'should not come up',
-    categoryAward: '',
-    ageRange: ALL_AGES,
-    image: Buffer(1),
   }),
+
+  // Instances
   'earned-badge-instance': new BadgeInstance({
     user: TESTUSER,
-    badge: '1234',
+    badge: 'earned',
   }),
   'city-math-instance': new BadgeInstance({
     user: TESTUSER,
@@ -180,6 +151,10 @@ test.applyFixtures({
       ageRange: Badge.ADULT
     }, function (err, badges) {
       const names = badges.map(prop('shortname'));
+
+      // misc
+      t.equal(contains(names, 'pure-science'), true,
+              'should contain pure-science badge');
       t.equal(contains(names, 'participation-science'), false,
               'no participation badges');
       t.equal(contains(names, 'city-science'), false,
@@ -192,16 +167,27 @@ test.applyFixtures({
               'no math badges, already earned category badge');
       t.equal(contains(names, 'pure-knitting'), false,
               'no badges that are off-track');
+
+      // age related
+      t.equal(contains(names, 'adult-science'), true,
+              'should contain adult-science badge');
       t.equal(contains(names, 'kid-science'), false,
               'no age-inappropriate badges');
       t.equal(contains(names, 'teen-science'), false,
               'no age-inappropriate badges');
-      t.equal(contains(names, 'pure-science'), true,
-              'should contain pure-science badge');
-      t.equal(contains(names, 'adult-science'), true,
-              'should contain adult-science badge');
+
+      // program related
+      t.equal(contains(names, 'in-progress-science'), true,
+              'should contain in-progress science badge');
+      t.equal(contains(names, 'not-yet-science'), false,
+              'no badges from inactive programs');
+      t.equal(contains(names, 'ended-science'), false,
+              'no badges from inactive programs');
+
+      // offline related
       t.equal(lastElem(names), 'offline-science',
               'should recommend offline badges last');
+
       console.dir(names);
       t.end();
     });

--- a/tests/badge-recommendations.test.js
+++ b/tests/badge-recommendations.test.js
@@ -6,6 +6,7 @@ const BadgeInstance = require('../models/badge-instance');
 const util = require('../lib/util');
 
 const TESTUSER = 'brian@example.org';
+const ALL_AGES = [Badge.KID, Badge.TEEN, Badge.ADULT];
 
 test.applyFixtures({
   'city-science': new Badge({
@@ -14,6 +15,7 @@ test.applyFixtures({
     name: 'City Science Badge',
     description: 'For earning a bunch of science badges',
     categoryAward: 'science',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'city-math': new Badge({
@@ -23,6 +25,7 @@ test.applyFixtures({
     name: 'City Math Badge',
     description: 'For earning a bunch of math badges',
     categoryAward: 'math',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'participation-science': new Badge({
@@ -33,6 +36,7 @@ test.applyFixtures({
     type: 'participation',
     activityType: 'online',
     categoryAward: '',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'offline-science': new Badge({
@@ -42,6 +46,7 @@ test.applyFixtures({
     description: 'For participating in offline science',
     type: 'achievement',
     activityType: 'offline',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'pure-science': new Badge({
@@ -52,6 +57,7 @@ test.applyFixtures({
     type: 'skill',
     activityType: 'online',
     categoryAward: '',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'pure-math': new Badge({
@@ -62,6 +68,40 @@ test.applyFixtures({
     type: 'skill',
     activityType: 'online',
     categoryAward: '',
+    ageRange: ALL_AGES,
+    image: Buffer(1),
+  }),
+  'kid-science': new Badge({
+    shortname: 'kid-science',
+    categories: ['science'],
+    name: 'Kid Science',
+    description: 'for sciencing (for kids)',
+    type: 'skill',
+    activityType: 'online',
+    categoryAward: '',
+    ageRange: ['0-13'],
+    image: Buffer(1),
+  }),
+  'teen-science': new Badge({
+    shortname: 'teen-science',
+    categories: ['science'],
+    name: 'Teen Science',
+    description: 'for sciencing (for teens)',
+    type: 'skill',
+    activityType: 'online',
+    categoryAward: '',
+    ageRange: ['13-18'],
+    image: Buffer(1),
+  }),
+  'adult-science': new Badge({
+    shortname: 'adult-science',
+    categories: ['science'],
+    name: 'Adult Science',
+    description: 'for sciencing (for teens)',
+    type: 'skill',
+    activityType: 'online',
+    categoryAward: '',
+    ageRange: ['18-24'],
     image: Buffer(1),
   }),
   'pure-knitting': new Badge({
@@ -71,6 +111,7 @@ test.applyFixtures({
     description: 'for knitting',
     type: 'skill',
     activityType: 'online',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'science-and-math': new Badge({
@@ -81,6 +122,7 @@ test.applyFixtures({
     activityType: 'online',
     description: 'for sciencing and mathing',
     categoryAward: '',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'earned-badge': new Badge({
@@ -92,6 +134,7 @@ test.applyFixtures({
     activityType: 'online',
     description: 'should not come up',
     categoryAward: '',
+    ageRange: ALL_AGES,
     image: Buffer(1),
   }),
   'earned-badge-instance': new BadgeInstance({
@@ -134,7 +177,7 @@ test.applyFixtures({
   test('recommended badges', function (t) {
     Badge.getRecommendations({
       email: TESTUSER,
-      age: 27
+      ageRange: Badge.ADULT
     }, function (err, badges) {
       const names = badges.map(prop('shortname'));
       t.equal(contains(names, 'participation-science'), false,
@@ -149,6 +192,14 @@ test.applyFixtures({
               'no math badges, already earned category badge');
       t.equal(contains(names, 'pure-knitting'), false,
               'no badges that are off-track');
+      t.equal(contains(names, 'kid-science'), false,
+              'no age-inappropriate badges');
+      t.equal(contains(names, 'teen-science'), false,
+              'no age-inappropriate badges');
+      t.equal(contains(names, 'pure-science'), true,
+              'should contain pure-science badge');
+      t.equal(contains(names, 'adult-science'), true,
+              'should contain adult-science badge');
       console.dir(names);
       t.end();
     });


### PR DESCRIPTION
Though we bias towards online badges, we will now also recommend offline
badges so long as they are active. A program is "active" if it's after
the start date, but before the end date (both inclusive).

This also takes into account a user age range so we don't recommend
age inappropriate badges.

**TODO**:
- Be smarter about recommending badges that will complete a
  category level badge.
- Be smarter about falling back when a filter reduces the
  recommendation set to zero items. For example, in the case
  where a user hasn't earned any badges yet, we are going to fall
  back completely to `allBadges`, but we should probably still
  filter out participation badges.
