### PR TITLE
Initial implementation of ClaimCode.reservedFor.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -317,6 +317,7 @@ Get a list of claim codes for a specific badge class.
 * **claimcodes**: Array of objects with the following properties:
   * **code**: The claim code
   * **claimed**: Boolean for whether it's claimed or not
+  * **reservedFor**: Which email address the code is reserved for, if any
 
 
 ## POST `/v2/badge/<shortname>/claimcodes`

--- a/models/badge.js
+++ b/models/badge.js
@@ -336,7 +336,12 @@ Badge.prototype.getClaimCodes = function getClaimCodes(opts) {
     : function (o) { return true };
 
   return codes.filter(filterFn).map(function (entry) {
-    return { code: entry.code, claimed: !!entry.claimedBy };
+    var claim = {
+      code: entry.code,
+      claimed: !!entry.claimedBy
+    };
+    if (entry.reservedFor) claim.reservedFor = entry.reservedFor;
+    return claim;
   });
 };
 

--- a/models/badge.js
+++ b/models/badge.js
@@ -384,7 +384,7 @@ Badge.prototype.earnableBy = function earnableBy(user) {
   }, true);
 };
 
-Badge.prototype.reserveAndEmail = function reserveAndEmail(email, callback) {
+Badge.prototype.reserveAndNotify = function reserveAndNotify(email, callback) {
   const self = this;
 
   BadgeInstance.findOne({
@@ -395,8 +395,7 @@ Badge.prototype.reserveAndEmail = function reserveAndEmail(email, callback) {
       return callback(null, null);
     self.generateClaimCodes({reservedFor: email}, function(err, accepted) {
       if (err) return callback(err);
-      console.log('WRITE SEND EMAIL CODE');
-      // #TODO: add email code here
+      console.log('TODO: WRITE NOTIFICATION/WEBHOOK CODE.');
       return callback(null, accepted[0]);
     });
   });

--- a/models/badge.js
+++ b/models/badge.js
@@ -382,13 +382,6 @@ Badge.prototype.earnableBy = function earnableBy(user) {
 Badge.prototype.reserveAndEmail = function reserveAndEmail(email, callback) {
   const self = this;
 
-  var existingCode = self.claimCodes.filter(function(claim) {
-    return claim.reservedFor == email;
-  });
-
-  if (existingCode.length)
-    return callback(null, null);
-
   BadgeInstance.findOne({
     userBadgeKey: email + '.' + self.id
   }, function (err, instance) {

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -245,11 +245,11 @@ exports.awardToUser = function awardToUser(req, res, next) {
   });
 };
 
-function reserveAndEmail(badge) {
+function reserveAndNotify(badge) {
   return function (email, callback) {
     if (!util.isEmail(email))
       return callback(null, {email: email, status: 'invalid'});
-    badge.reserveAndEmail(email, function (err, claimCode) {
+    badge.reserveAndNotify(email, function (err, claimCode) {
       if (err) return callback(err);
       if (!claimCode)
         return callback(null, {email: email, status: 'dupe'});
@@ -269,7 +269,7 @@ exports.issueMany = function issueMany(req, res, next) {
     .trim()
     .split('\n')
     .map(util.method('trim'));
-  async.map(emails, reserveAndEmail(badge), function (err, results) {
+  async.map(emails, reserveAndNotify(badge), function (err, results) {
     if (err) return next(err);
     req.flash('results', results);
     return res.redirect(303, 'back');

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -163,7 +163,9 @@ exports.meta = function meta(req, res) {
 
 exports.getUnclaimedCodesTxt = function getUnclaimedCodesTxt(req, res, next) {
   var codes = req.badge.claimCodes
-    .filter(function(c) { return !c.claimedBy && !c.multi; })
+    .filter(function(c) {
+      return !c.claimedBy && !c.multi && !c.reservedFor;
+    })
     .map(util.prop('code'));
   return res.type('text').send(200, codes.join('\n'));
 };

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -78,6 +78,7 @@ module.exports = {
       { code: 'already-claimed', claimedBy: 'brian@example.org' },
       { code: 'never-claim' },
       { code: 'will-claim' },
+      { code: 'reserved-claim', reservedFor: 'foo@bar.org' },
       { code: 'remove-claim' },
     ]
   }),

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -42,6 +42,9 @@ module.exports = {
     shortname: 'link-advanced',
     description: 'For doing lots of links.',
     image: IMAGE,
+    claimCodes: [
+      { code: 'NARGS_CODE', reservedFor: 'narg@moose.org' },
+    ],
     behaviors: [
       { shortname: 'link', count: 10 }
     ]

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -492,20 +492,20 @@ test.applyFixtures(fixtures, function () {
     });
   });
 
-  test('Badge#reserveAndEmail does nothing when user already has badge', function(t) {
+  test('Badge#reserveAndNotify does nothing when user already has badge', function(t) {
     var badge = fixtures['link-comment'];
     var email = fixtures['user'].user;
-    badge.reserveAndEmail(email, function(err, claimCode) {
+    badge.reserveAndNotify(email, function(err, claimCode) {
       if (err) throw err;
       t.same(claimCode, null, "user already has badge");
       t.end();
     });
   });
 
-  test('Badge#reserveAndEmail creates reserved claim code', function(t) {
+  test('Badge#reserveAndNotify creates reserved claim code', function(t) {
     var badge = fixtures['random-badge'];
     var email = fixtures['user'].user;
-    badge.reserveAndEmail(email, function(err, claimCode) {
+    badge.reserveAndNotify(email, function(err, claimCode) {
       if (err) throw err;
       t.equal(typeof(claimCode), 'string');
       var claim = badge.getClaimCode(claimCode);
@@ -514,10 +514,10 @@ test.applyFixtures(fixtures, function () {
     });
   });
 
-  test('Badge#reserveAndEmail makes more codes when user has reserved claim code because user might be a guardian with lots of kids', function(t) {
+  test('Badge#reserveAndNotify makes more codes when user has reserved claim code because user might be a guardian with lots of kids', function(t) {
     var badge = fixtures['random-badge'];
     var email = fixtures['user'].user;
-    badge.reserveAndEmail(email, function(err, claimCode) {
+    badge.reserveAndNotify(email, function(err, claimCode) {
       if (err) throw err;
       t.equal(typeof(claimCode), 'string');
       var claim = badge.getClaimCode(claimCode);

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -490,6 +490,38 @@ test.applyFixtures(fixtures, function () {
     });
   });
 
+  test('Badge#reserveAndEmail does nothing when user already has badge', function(t) {
+    var badge = fixtures['link-comment'];
+    var email = fixtures['user'].user;
+    badge.reserveAndEmail(email, function(err, claimCode) {
+      if (err) throw err;
+      t.same(claimCode, null, "user already has badge");
+      t.end();
+    });
+  });
+
+  test('Badge#reserveAndEmail creates reserved claim code', function(t) {
+    var badge = fixtures['random-badge'];
+    var email = fixtures['user'].user;
+    badge.reserveAndEmail(email, function(err, claimCode) {
+      if (err) throw err;
+      t.equal(typeof(claimCode), 'string');
+      var claim = badge.getClaimCode(claimCode);
+      t.equal(claim.reservedFor, email, "reserved claim code is generated");
+      t.end();
+    });
+  });
+
+  test('Badge#reserveAndEmail does nothing when user has reserved claim code', function(t) {
+    var badge = fixtures['random-badge'];
+    var email = fixtures['user'].user;
+    badge.reserveAndEmail(email, function(err, claimCode) {
+      if (err) throw err;
+      t.same(claimCode, null, "user already has reserved claim code");
+      t.end();
+    });
+  });
+
   // necessary to stop the test runner
   test('shutting down #', function (t) {
     db.close();

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -301,6 +301,7 @@ test.applyFixtures(fixtures, function () {
       {code: 'already-claimed', claimed: true},
       {code: 'never-claim', claimed: false},
       {code: 'will-claim', claimed: false},
+      {code: 'reserved-claim', reservedFor: 'foo@bar.org', claimed: false },
       {code: 'remove-claim', claimed: false},
     ];
 ;
@@ -313,7 +314,8 @@ test.applyFixtures(fixtures, function () {
     const expect = [
       {code: 'never-claim', claimed: false},
       {code: 'will-claim', claimed: false},
-      {code: 'remove-claim', claimed: false},
+      {code: 'reserved-claim', reservedFor: 'foo@bar.org', claimed: false },
+      {code: 'remove-claim', claimed: false}
     ];
     t.same(badge.getClaimCodes({unclaimed: true}), expect);
     t.end();

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -512,12 +512,14 @@ test.applyFixtures(fixtures, function () {
     });
   });
 
-  test('Badge#reserveAndEmail does nothing when user has reserved claim code', function(t) {
+  test('Badge#reserveAndEmail makes more codes when user has reserved claim code because user might be a guardian with lots of kids', function(t) {
     var badge = fixtures['random-badge'];
     var email = fixtures['user'].user;
     badge.reserveAndEmail(email, function(err, claimCode) {
       if (err) throw err;
-      t.same(claimCode, null, "user already has reserved claim code");
+      t.equal(typeof(claimCode), 'string');
+      var claim = badge.getClaimCode(claimCode);
+      t.equal(claim.reservedFor, email, "another reserved claim code is generated because the email might be for a guardian who has multiple kids");
       t.end();
     });
   });

--- a/tests/badge-route.test.js
+++ b/tests/badge-route.test.js
@@ -189,6 +189,37 @@ test.applyFixtures(badgeFixtures, function(fx) {
     });
   });
 
+  test('reserving badges for users works', function(t) {
+    var flashes = [];
+    conmock({
+      handler: badge.issueMany,
+      request: {
+        badge: fx['link-advanced'],
+        flash: function(type, results) {
+          flashes.push({type: type, results: results});
+        },
+        body: {
+          emails: 'blarg@goose.org\nnarg@moose.org'
+        }
+      }
+    }, function(err, mockRes, req) {
+      if (err) throw err;
+      t.equal(mockRes.status, 303);
+      t.equal(mockRes.path, 'back');
+      t.equal(flashes.length, 1);
+      t.equal(flashes[0].type, 'results');
+      t.equal(flashes[0].results.length, 2);
+      var success = flashes[0].results[0];
+      var dupe = flashes[0].results[1];
+      t.equal(success.email, 'blarg@goose.org');
+      t.equal(success.status, 'ok');
+      t.equal(typeof(success.claimCode), 'string');
+      t.equal(dupe.email, 'narg@moose.org');
+      t.equal(dupe.status, 'dupe');
+      t.end();
+    });
+  });
+
   test('shutting down #', function (t) {
     db.close(); t.end();
   });

--- a/tests/badge-route.test.js
+++ b/tests/badge-route.test.js
@@ -207,6 +207,7 @@ test.applyFixtures(badgeFixtures, function(fx) {
       t.equal(mockRes.status, 303);
       t.equal(mockRes.path, 'back');
       t.equal(flashes.length, 1);
+      t.ok(flashes[0]);
       t.equal(flashes[0].type, 'results');
       t.equal(flashes[0].results.length, 2);
       var success = flashes[0].results[0];

--- a/tests/badge-route.test.js
+++ b/tests/badge-route.test.js
@@ -210,12 +210,13 @@ test.applyFixtures(badgeFixtures, function(fx) {
       t.equal(flashes[0].type, 'results');
       t.equal(flashes[0].results.length, 2);
       var success = flashes[0].results[0];
-      var dupe = flashes[0].results[1];
+      var success2 = flashes[0].results[1];
       t.equal(success.email, 'blarg@goose.org');
       t.equal(success.status, 'ok');
       t.equal(typeof(success.claimCode), 'string');
-      t.equal(dupe.email, 'narg@moose.org');
-      t.equal(dupe.status, 'dupe');
+      t.equal(success2.email, 'narg@moose.org');
+      t.equal(success2.status, 'ok');
+      t.equal(typeof(success2.claimCode), 'string');      
       t.end();
     });
   });

--- a/views/admin/manage-claim-codes.html
+++ b/views/admin/manage-claim-codes.html
@@ -49,6 +49,7 @@
       <tr>
         <th>Code</th>
         <th>Claimed By</th>
+        <th>Reserved For</th>
         <th>Actions</td>
       </tr>
     </thead>
@@ -61,6 +62,13 @@
             *multi*
           {% else %}
             {{ claim.claimedBy | default('<em>open</em>') }}
+          {% endif %}
+        </td>
+        <td>
+          {% if claim.reservedFor %}
+          {{claim.reservedFor}}
+          {% else %}
+          anyone
           {% endif %}
         </td>
         <td>


### PR DESCRIPTION
## Motivation and Rationale

Issuing badges from the OpenBadger admin interface is problematic because there's a lot of information we need to know to issue a badge to the proper recipient and notify them of the issuance.

For example, if the recipient is < 13, the email address entered in the OpenBadger admin UI might be the guardian's email. While that guardian should be notified about the badge issuance, we don't actually know which email to issue the badge to yet, as the guardian will need to pick a child to actually award the badge to. Only CSOL-site knows about what children a guardian has stewardship over, and as it's the only learner/guardian-facing website, it makes sense for it to be the one that sends an email with any necessary links back to itself.

Thus rather than immediately issuing a badge and emailing its recipient, it makes more sense for Openbadger to create a kind of claim code that's "reserved" for someone, and then notify CSOL-site about the reservation via a webhook. This allows CSOL-site to handle the situation in the best way possible. Here's some examples of what CSOL-site might do, which OpenBadger doesn't have the knowledge to do itself:
- If the email address doesn't exist as an account on CSOL-site, CSOL-site can automatically create an account for them (reducing signup friction) and then invite the user to it so they can either issue the badge to their kid (if they turn out to be a guardian) or have it immediately issued to themself (if they're a learner over 13).
- If the email is known to be a guardian, CSOL-site can email the user with a link back to itself so they can choose what kid to award it to.
- If the email is known to be a > 13 learner, CSOL-site can automatically claim the badge for them and notify them via email.

Also, for #122, where we want to allow OpenBadger issuers/admins to issue badges _with evidence_, we must acknowledge that OpenBadger itself has no concept of evidence other than a single URL in an open badge assertion: every individual piece of evidence is actually stored and displayed to users by CSOL-site, not OpenBadger. Thus, one way of implementing this feature will be to (eventually) add additional fields to reserved claims that allow them to temporarily hold evidence uploaded by issuers/admins, at which point CSOL-site can fetch them when notified of the reserved claim.
## Implementation

This pull request implements the notion of a reserved claim code in the badge/claim model, along with a new Badge method, `reserveAndNotify()`, which creates a reserved claim code, and changes the `issueMany` badge route to call it.

Things left to do (either by this PR or subsequent ones):
- [x] Call a webhook when `reserveAndNotify()` is called, defined by an environment variable such as `OPENBADGER_NOTIFICATION_WEBHOOK`. This has been split out into #190.
- [x] Make the POST `/v2/user/badge/<shortname>` and POST `/v2/claim` API endpoints return information about any STEAM badges that were also awarded. This will allow CSOL-site (or other trusted clients like DYN) to send email notifications itself whenever it issues badges, by simply looking at the return value of the API call. (This implies that the webhook will only be called when a badge is "issued" from the OpenBadger UI.) This has been split out into #191.
- [x] Documenting the changes to the above API endpoints in `docs/api.md`. Also documenting that their callers are responsible for communicating the awarding of any badges made as a result (including STEAM badges) to the recipient. This has become part of #191.
