### PR TITLE
Address performance issues on front page

### DIFF
--- a/routes/badge.js
+++ b/routes/badge.js
@@ -377,8 +377,22 @@ exports.findByIssuers = function findByIssuers(req, res, next) {
     });
 };
 
+function parseLimit(limit, _default) {
+  const DEFAULT = _default || 50;
+  const intLimit = parseInt(limit, 10);
+  if (intLimit === 0)
+    return Infinity;
+  return intLimit || DEFAULT;
+}
+
 exports.findAll = function findAll(req, res, next) {
-  Badge.find({}, {image: 0})
+  const page = req.page = parseInt(req.query.page, 10) || 1;
+  const limitAmount = req.limit = parseLimit(req.query.limit);
+  const skipAmount = limitAmount * (page - 1);
+  const importantElements = {name: 1, shortname: 1, program: 1};
+  Badge.find({}, importantElements)
+    .limit(limitAmount)
+    .skip(skipAmount)
     .populate('program')
     .exec(function (err, badges) {
       if (err) return next(err);

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -359,7 +359,8 @@ exports.findByIssuers = function findByIssuers(req, res, next) {
       .map(util.prop('_id'))
       .map(util.objWrap('program'))
   };
-  Badge.find(query)
+  Badge
+    .find(query, {image: 0})
     .populate('program')
     .exec(function (err, badges) {
       if (err) return next(err);
@@ -377,31 +378,8 @@ exports.findByIssuers = function findByIssuers(req, res, next) {
 };
 
 exports.findAll = function findAll(req, res, next) {
-  Badge.find({})
+  Badge.find({}, {image: 0})
     .populate('program')
-    .exec(function (err, badges) {
-      if (err) return next(err);
-      req.badges = badges;
-      const programs = badges
-        .filter(util.prop('program'))
-        .map(util.prop('program'));
-      const populateIssuers = util.method('populate', 'issuer');
-      async.map(programs, populateIssuers, function (err) {
-        if (err) return next(err);
-        return next();
-      });
-    });
-};
-
-exports.findNonOffline = function findNonOffline(req, res, next) {
-  var query = {
-    '$or': [
-      {claimCodes: {'$exists': false }} ,
-      {claimCodes: {'$size': 0 }}
-    ]
-  };
-  Badge.find(query)
-   .populate('program')
     .exec(function (err, badges) {
       if (err) return next(err);
       req.badges = badges;

--- a/routes/index.js
+++ b/routes/index.js
@@ -17,7 +17,7 @@ whitelists.NO_CACHE = [whitelists.ASSERTION];
 
 exports.define = function defineRoutes(app) {
   /** Routes */
-  app.get('/', badge.findNonOffline, render.all);
+  app.get('/', render.anonymousHome);
 
   app.all('/issuer*', user.requireAuth({
     level: 'issuer',

--- a/routes/index.js
+++ b/routes/index.js
@@ -47,7 +47,6 @@ exports.define = function defineRoutes(app) {
   // -------------
   var indexMiddleware = [
     badge.findAll,
-    behavior.findAll,
     issuer.findAll,
   ];
 

--- a/routes/issuer.js
+++ b/routes/issuer.js
@@ -9,8 +9,7 @@ const method = util.method;
 const prop = util.prop;
 
 exports.findAll = function findAll(req, res, next) {
-  Issuer.find({})
-    .populate('programs')
+  Issuer.find({}, {image: 0})
     .exec(function (err, issuers) {
       if (err) return next(err);
       req.issuers = issuers;

--- a/routes/issuer.js
+++ b/routes/issuer.js
@@ -9,7 +9,7 @@ const method = util.method;
 const prop = util.prop;
 
 exports.findAll = function findAll(req, res, next) {
-  Issuer.find({}, {image: 0})
+  Issuer.find({}, {name: 1})
     .exec(function (err, issuers) {
       if (err) return next(err);
       req.issuers = issuers;

--- a/routes/render.js
+++ b/routes/render.js
@@ -144,9 +144,8 @@ exports.criteria = function criteria(req, res) {
   });
 }
 
-exports.all = function all(req, res) {
-  return res.render('public/all.html', {
-    badges: req.badges,
+exports.anonymousHome = function all(req, res) {
+  return res.render('public/anonymous-home.html', {
     user: req.session.user,
     csrf: req.session._csrf,
   });

--- a/routes/render.js
+++ b/routes/render.js
@@ -115,6 +115,10 @@ exports.newBehaviorForm = function (req, res) {
 exports.badgeIndex = function (req, res) {
   return res.render('admin/badge-index.html', {
     page: 'home',
+
+    limit: req.limit,
+    pageNumber: req.page,
+
     issuers: req.issuers,
     user: req.session.user,
     access: req.session.access,

--- a/themes/csol/views/admin/badge-index.html
+++ b/themes/csol/views/admin/badge-index.html
@@ -14,7 +14,12 @@
       <a href="?limit={{limit}}&page={{pageNumber-1}}">
         <button class="btn">Previous Page</button>
       </a>
+
+    {% else %}
+      <button class="btn disabled">Previous Page</button>
     {% endif %}
+
+
     <a href="?limit={{limit}}&page={{pageNumber+1}}">
       <button class="btn">Next Page</button>
     </a>

--- a/themes/csol/views/admin/badge-index.html
+++ b/themes/csol/views/admin/badge-index.html
@@ -1,17 +1,6 @@
 {% extends "admin/base.html" %}
 {% block main %}
 
-{% if badges.length %}
-<table class="badge-list">
-<tbody>
-<tr>
-<th class="oper view"></th>
-<th class="orga">Organization</th>
-<th class="prog">Program</th>
-<th class="badg">Badge</th>
-<th class="oper all"></th>
-</tr>
-
 <div>
   <p>
     {% if limit == "Infinity" %}
@@ -32,6 +21,18 @@
     {% endif %}
 
 </div>
+
+
+{% if badges.length %}
+<table class="badge-list">
+<tbody>
+<tr>
+<th class="oper view"></th>
+<th class="orga">Organization</th>
+<th class="prog">Program</th>
+<th class="badg">Badge</th>
+<th class="oper all"></th>
+</tr>
 
 {% for badge in badges %}
   <tr>

--- a/themes/csol/views/admin/badge-index.html
+++ b/themes/csol/views/admin/badge-index.html
@@ -11,6 +11,28 @@
 <th class="badg">Badge</th>
 <th class="oper all"></th>
 </tr>
+
+<div>
+  <p>
+    {% if limit == "Infinity" %}
+    <a href="?">Limit Results</a>
+    {% else %}
+
+    <strong>Page</strong>: {{ pageNumber }}, <strong>Limit</strong>: {{ limit }}
+      (<a href="?limit=0">show all</a>)
+    </p>
+    {% if pageNumber != 1 %}
+      <a href="?limit={{limit}}&page={{pageNumber-1}}">
+        <button class="btn">Previous Page</button>
+      </a>
+    {% endif %}
+    <a href="?limit={{limit}}&page={{pageNumber+1}}">
+      <button class="btn">Next Page</button>
+    </a>
+    {% endif %}
+
+</div>
+
 {% for badge in badges %}
   <tr>
     <td class="oper view">

--- a/themes/csol/views/public/anonymous-home.html
+++ b/themes/csol/views/public/anonymous-home.html
@@ -57,12 +57,10 @@
       {% else %}
         {{ badge.description | stupidSafe }}
       {% endif %}
-    </td>  
+    </td>
   </tr>
 {% endfor %}
 </tbody>
 </table>
-{% else %}
-<h1>No Badges to issue.</h1>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
This implements a few of strategies to performance. On the default, "show everything" page I went from ~6 second response times to ~900ms. On the paginated pages, responses are close to instantaneous.
- **Don't populate programs for issuers.** We aren't using them, and populations are expensive.
- **Only pull the data we need from the database.** For badges, that's `name`, `shortname`, and `program` (for population). For issuers, all we need is `name`.
- **Implement cheap pagination.** I set a default of 50 items, added some "next" and "previous" buttons to the frontend and called it a day. I also added a "show all" link to revert to previous behavior of listing everything. Ideally, I'd also add a search functionality but this is quick & dirty optimization, not perfect.
