### PR TITLE
Add batch names to claim codes, printable handouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ export OPENBADGER_REDIS_PORT=6379
 export OPENBADGER_MONGO_HOST="localhost"
 export OPENBADGER_MONGO_PORT=27017
 export OPENBADGER_MONGO_DB="openbadger"
+export OPENBADGER_CLAIM_URL_TEXT='csol.org/claim'
 export OPENBADGER_ADMINS='["*@mozilla(foundation)?.org"]'
 ```
 

--- a/models/badge.js
+++ b/models/badge.js
@@ -235,6 +235,7 @@ function inArray(array, thing) {
  *   - `limit`: Maximum number of codes to add. [default: Infinity]
  *   - `multi`: Whether or not the claim is multi-use
  *   - `reservedFor`: Who the claim code is reserved for
+ *   - `batchName`: Batch name of the claim code
  *   - `alreadyClean`: Boolean whether or not items are already unique
  * @param {Function} callback
  *   Expects `function (err, accepted, rejected)`
@@ -274,6 +275,7 @@ Badge.prototype.addClaimCodes = function addClaimCodes(options, callback) {
       this.claimCodes.push({
         code: code,
         multi: options.multi,
+        batchName: options.batchName,
         reservedFor: options.reservedFor
       });
     }.bind(this));
@@ -291,6 +293,7 @@ Badge.prototype.addClaimCodes = function addClaimCodes(options, callback) {
  * @param {Object} options
  *   - `count`: how many codes to generate
  *   - `codeGenerator`: function to generate random codes (optional)
+ *   - `batchName`: batch name to give to each generated code
  *   - `reservedFor`: email address to reserve the claim code for.
  *       count=1 is implicit when this is non-falsy.
  * @param {Function} callback
@@ -303,6 +306,7 @@ Badge.prototype.addClaimCodes = function addClaimCodes(options, callback) {
 Badge.prototype.generateClaimCodes = function generateClaimCodes(options, callback) {
   const codeGenerator = options.codeGenerator || phraseGenerator;
   const reservedFor = options.reservedFor;
+  const batchName = options.batchName;
   const accepted = [];
   const self = this;
   var count = options.count;
@@ -318,6 +322,7 @@ Badge.prototype.generateClaimCodes = function generateClaimCodes(options, callba
       codes: phrases,
       limit: numLeft,
       reservedFor: reservedFor,
+      batchName: batchName,
       alreadyClean: true,
     }, function (err, acceptedCodes, rejectedCodes) {
       if (err) return cb(err);

--- a/models/badge.js
+++ b/models/badge.js
@@ -355,6 +355,15 @@ Badge.prototype.getBatchNames = function getBatchNames() {
   return Object.keys(batchNames);
 };
 
+Badge.prototype.getClaimCodesForDistribution = function getClaimCodesForDistribution(batchName) {
+  return this.claimCodes
+    .filter(function(c) {
+      if (batchName && c.batchName != batchName) return false;
+      return !c.claimedBy && !c.multi && !c.reservedFor;
+    })
+    .map(util.prop('code'));
+};
+
 Badge.prototype.getClaimCodes = function getClaimCodes(opts) {
   opts = _.defaults(opts||{}, {unclaimed: false});
 

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -183,11 +183,18 @@ exports.addClaimCodes = function addClaimCodes(req, res, next) {
       .split('\n')
       .map(util.method('trim'))
       .filter(util.prop('length'));
-    badge.addClaimCodes({codes: codes, multi: !!form.multi}, goBack);
+    badge.addClaimCodes({
+      codes: codes,
+      multi: !!form.multi,
+      batchName: form.batchName
+    }, goBack);
   } else if (form.quantity) {
     var count = parseInt(form.quantity);
     if (count > 0) {
-      badge.generateClaimCodes({count: count}, goBack);
+      badge.generateClaimCodes({
+        count: count,
+        batchName: form.batchName
+      }, goBack);
     } else
       goBack();
   }

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -161,13 +161,7 @@ exports.meta = function meta(req, res) {
 };
 
 exports.getUnclaimedCodesTxt = function getUnclaimedCodesTxt(req, res, next) {
-  var batchName = req.query.batchName;
-  var codes = req.badge.claimCodes
-    .filter(function(c) {
-      if (batchName && c.batchName != batchName) return false;
-      return !c.claimedBy && !c.multi && !c.reservedFor;
-    })
-    .map(util.prop('code'));
+  var codes = req.badge.getClaimCodesForDistribution(req.query.batchName);
   return res.type('text').send(200, codes.join('\n'));
 };
 
@@ -225,6 +219,10 @@ exports.releaseClaimCode = function releaseClaimCode(req, res, next) {
 var bulkClaimCodeActions = exports.bulkClaimCodeActions = {
   txt: function(req, res, next) {
     return res.redirect(303, '../unclaimed.txt?batchName=' +
+                             encodeURIComponent(req.body.batchName));
+  },
+  html: function(req, res, next) {
+    return res.redirect(303, '../unclaimed.html?batchName=' +
                              encodeURIComponent(req.body.batchName));
   }
 };

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -2,7 +2,6 @@ const _ = require('underscore');
 const fs = require('fs');
 const logger = require('../lib/logger');
 const Badge = require('../models/badge');
-const phrases = require('../lib/phrases');
 const BadgeInstance = require('../models/badge-instance');
 const util = require('../lib/util');
 const async = require('async');
@@ -171,30 +170,27 @@ exports.getUnclaimedCodesTxt = function getUnclaimedCodesTxt(req, res, next) {
 };
 
 exports.addClaimCodes = function addClaimCodes(req, res, next) {
-  var codes = [];
-  var count;
+  function goBack(err) {
+    if (err) return next(err);
+    return res.redirect('back');
+  }
+
   const badge = req.badge;
   const form = req.body;
 
   if (form.codes) {
-    codes = form.codes
+    var codes = form.codes
       .split('\n')
       .map(util.method('trim'))
       .filter(util.prop('length'));
+    badge.addClaimCodes({codes: codes, multi: !!form.multi}, goBack);
   } else if (form.quantity) {
-    count = parseInt(form.quantity);
-    if (count > 0)
-      codes = phrases(count);
+    var count = parseInt(form.quantity);
+    if (count > 0) {
+      badge.generateClaimCodes({count: count}, goBack);
+    } else
+      goBack();
   }
-
-  const options = {
-    codes: codes,
-    multi: !!form.multi
-  };
-  badge.addClaimCodes(options, function(err) {
-    if (err) return next(err);
-    return res.redirect('back');
-  });
 };
 
 exports.removeClaimCode = function removeClaimCode(req, res, next) {

--- a/routes/index.js
+++ b/routes/index.js
@@ -74,6 +74,8 @@ exports.define = function defineRoutes(app) {
            badge.bulkClaimCodeAction);
   app.get('/admin/badge/:shortname/claims/unclaimed.txt',
           badge.getUnclaimedCodesTxt);
+  app.get('/admin/badge/:shortname/claims/unclaimed.html',
+          render.getUnclaimedCodesHtml);
 
   app.post('/admin/badge', [
     badge.getUploadedImage({ required: true })

--- a/routes/index.js
+++ b/routes/index.js
@@ -70,7 +70,9 @@ exports.define = function defineRoutes(app) {
   app.get('/admin/badge/:shortname', [behavior.findAll], render.showBadge);
   app.get('/admin/badge/:shortname/edit', render.editBadgeForm);
   app.get('/admin/badge/:shortname/claims/', render.manageClaimCodes);
-  app.get('/admin/badge/:shortname/unclaimed.txt',
+  app.post('/admin/badge/:shortname/claims/bulk-action',
+           badge.bulkClaimCodeAction);
+  app.get('/admin/badge/:shortname/claims/unclaimed.txt',
           badge.getUnclaimedCodesTxt);
 
   app.post('/admin/badge', [

--- a/routes/render.js
+++ b/routes/render.js
@@ -187,6 +187,15 @@ exports.manageClaimCodes = function (req, res) {
   });
 };
 
+exports.getUnclaimedCodesHtml = function (req, res) {
+  return res.render('admin/claim-code-printout.html', {
+    badge: req.badge,
+    batchName: req.query.batchName,
+    claimUrlText: process.env.OPENBADGER_CLAIM_URL_TEXT,
+    claimCodes: req.badge.getClaimCodesForDistribution(req.query.batchName),
+  });
+};
+
 exports.showFlushDbForm = function (req, res) {
   return res.render('admin/flush-user-info.html', {
     page: 'flush',

--- a/tests/badge-model.test.js
+++ b/tests/badge-model.test.js
@@ -526,6 +526,46 @@ test.applyFixtures(fixtures, function () {
     });
   });
 
+  test("claim codes have a creationDate", function(t) {
+    t.ok(fixtures['offline-badge'].claimCodes[0].creationDate instanceof Date);
+    t.end();
+  });
+
+  test("Badge#getBatchNames", function(t) {
+    var badge = validBadge();
+    badge.claimCodes.push({
+      code: 'a',
+      batchName: 'lol'
+    });
+    badge.claimCodes.push({
+      code: 'b',
+      batchName: 'lol'
+    });
+    badge.claimCodes.push({
+      code: 'c',
+      batchName: 'heh'
+    });
+    badge.claimCodes.push({
+      code: 'd'
+    });
+
+    t.same(badge.getBatchNames(), ['lol', 'heh']);
+
+    t.same(badge.getClaimCodes({batchName: 'lol'}), [{
+      code: 'a',
+      claimed: false,
+      batchName: 'lol'
+    }, {
+      code: 'b',
+      claimed: false,
+      batchName: 'lol'
+    }]);
+
+    t.end();
+  });
+
+
+
   // necessary to stop the test runner
   test('shutting down #', function (t) {
     db.close();

--- a/tests/badge-route.test.js
+++ b/tests/badge-route.test.js
@@ -50,13 +50,15 @@ test.applyFixtures(badgeFixtures, function(fx) {
       request: {
         badge: b,
         body: {
-          quantity: '3'
+          quantity: '3',
+          batchName: 'foo'
         }
       }
     }, function(err, mockRes, req) {
       if (err) throw err;
       t.equal(mockRes.status, 301);
       t.equal(b.claimCodes.length, 3);
+      t.equal(b.getClaimCodes({batchName: 'foo'}).length, 3);
       t.end();
     });
   });
@@ -68,13 +70,15 @@ test.applyFixtures(badgeFixtures, function(fx) {
       request: {
         badge: b,
         body: {
-          codes: 'blarg\nflarg\n\n\narg'
+          codes: 'blarg\nflarg\n\n\narg',
+          batchName: 'meh'
         }
       }
     }, function(err, mockRes, req) {
       if (err) throw err;
       t.equal(mockRes.status, 301);
       t.same(b.claimCodes.map(util.prop('code')), ['blarg', 'flarg', 'arg']);
+      t.equal(b.getClaimCodes({batchName: 'meh'}).length, 3);
       t.end();
     });
   });

--- a/tests/badge-route.test.js
+++ b/tests/badge-route.test.js
@@ -22,6 +22,51 @@ test.applyFixtures(badgeFixtures, function(fx) {
     });
   });
 
+  test('getting open claim codes as txt w/ batchName works', function(t) {
+    conmock({
+      handler: badge.getUnclaimedCodesTxt,
+      request: {
+        badge: fx['offline-badge'],
+        query: {batchName: 'LOLOL'}
+      }
+    }, function(err, mockRes, req) {
+      if (err) throw err;
+      t.equal(mockRes.status, 200);
+      t.equal(mockRes.headers['Content-Type'], 'text/plain');
+      t.equal(mockRes.body, '');
+      t.end();
+    });
+  });
+
+  test('invalid bulk action returns 400', function(t) {
+    conmock({
+      handler: badge.bulkClaimCodeAction,
+      request: {
+        badge: fx['offline-badge'],
+        body: {action: 'LOLOL'}
+      }
+    }, function(err, mockRes, req) {
+      if (err) throw err;
+      t.equal(mockRes.status, 400);
+      t.end();
+    });    
+  });
+
+  test('txt bulk action returns redirect', function(t) {
+    conmock({
+      handler: badge.bulkClaimCodeAction,
+      request: {
+        badge: fx['offline-badge'],
+        body: {action: 'txt', batchName: 'foo bar'}
+      }
+    }, function(err, mockRes, req) {
+      if (err) throw err;
+      t.equal(mockRes.status, 303);
+      t.equal(mockRes.path, '../unclaimed.txt?batchName=foo%20bar');
+      t.end();
+    });    
+  });
+
   test('adding no claim codes does nothing', function(t) {
     var b = fx['link-basic'];
     t.equal(b.claimCodes.length, 0);

--- a/views/admin/claim-code-printout.html
+++ b/views/admin/claim-code-printout.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+div.cutout {
+  display: inline-block;
+  vertical-align: top;
+  width: 2in;
+  min-height: 3in;
+  border: 1px dotted black;
+  margin: 0.1in;
+}
+
+div.cutout .badge {
+  display: block;
+  width: 1.75in;
+  padding: 0;
+  margin: 0.125in;
+}
+
+div.cutout .text {
+  margin: 0 0.125in 0.125in 0.125in;
+  font-size: 9pt;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  text-align: center;
+}
+
+div.cutout .text .title {
+  display: block;
+  font-weight: bold;
+}
+
+div.cutout .text .claim {
+  display: block;
+  font-family: Monaco, Menlo, monospace;
+}
+
+.claim-url-text {
+  text-decoration: underline;
+}
+</style>
+<title>Claim Codes{% if batchName %}, batch {{batchName}}{% endif %}</title>
+{% for code in claimCodes %}
+<div class="cutout">
+  <img class="badge" src="{{ badge.relativeUrl('image') }}">
+  <div class="text">
+    <span class="title">{{ badge.name }}</span>
+    <p>To redeem this badge, go to 
+      {% if claimUrlText %}
+      <span class="claim-url-text">{{ claimUrlText }}</span>
+      {% else %}
+      the website
+      {% endif %}
+      and use the claim code</p>
+    <span class="claim">{{ code }}</span>
+  </div>
+</div>
+{% endfor %}

--- a/views/admin/manage-claim-codes.html
+++ b/views/admin/manage-claim-codes.html
@@ -104,8 +104,22 @@
       {% endfor %}
     </tbody>
   </table>
-  <a href="../unclaimed.txt" target="_blank" class="btn btn-small">Export all open codes as plain text</a>
-</form>
+  <form class="form-inline" action="bulk-action" method="post">
+    <legend>Bulk Actions</legend>
+    <input type="hidden" name="csrf" value="{{ csrf }}">
+    <label>Apply the action</label>
+    <select name="action" class="input-xlarge">
+      <option value="txt">Export open codes as plain text</option>
+    </select>
+    <label>to claim codes in batch</label>
+    <select name="batchName">
+      <option value="">(All claim codes)</option>
+      {% for batchname in badge.getBatchNames() %}
+      <option value="{{batchname}}">{{batchname}}</option>
+      {% endfor %}
+    </select>
+    <button type="submit" class="btn btn-primary">Go</button>
+  </form>
 
 {% endif %}
 {% endblock %}

--- a/views/admin/manage-claim-codes.html
+++ b/views/admin/manage-claim-codes.html
@@ -110,6 +110,7 @@
     <label>Apply the action</label>
     <select name="action" class="input-xlarge">
       <option value="txt">Export open codes as plain text</option>
+      <option value="html">Export printable handouts</option>
     </select>
     <label>to claim codes in batch</label>
     <select name="batchName">

--- a/views/admin/manage-claim-codes.html
+++ b/views/admin/manage-claim-codes.html
@@ -34,6 +34,15 @@
     <form method="post" action="?">
       <label>Number of codes</label>
       <input type="number" name="quantity" value="5" required>
+      <label>Batch name</label>
+      <input type="text" name="batchName">
+      <span class="help-block">
+        If you give a name to this batch of claim codes, you will be
+        able to easily print out all the claim codes in the batch,
+        track statistics on them, and more. A useful batch name might be
+        the name of the event where you hand out the claim codes, e.g.
+        "World Environment Day event".
+      </span>
       <div class="form-actions">
         <input type="hidden" name="csrf" value="{{ csrf }}">
         <input type="submit" value="Generate codes" class="btn btn-primary">
@@ -48,6 +57,7 @@
     <thead>
       <tr>
         <th>Code</th>
+        <th>Batch Name</th>
         <th>Claimed By</th>
         <th>Reserved For</th>
         <th>Actions</td>
@@ -57,6 +67,13 @@
       {% for claim in codes %}
       <tr>
         <td>{{ claim.code }}</td>
+        <td>
+          {% if claim.batchName %}
+          {{ claim.batchName }}
+          {% else %}
+          <em>none</em>
+          {% endif %}
+        </td>
         <td>
           {% if claim.multi %}
             *multi*


### PR DESCRIPTION
This PR resolves #184.

Admins can now (optionally) assign names to the batches of claim codes that they generate. This will allow them to execute actions on specific batches.

Here's an example of the claim code generation form with this PR merged:

![screen shot 2013-06-06 at 8 41 06 am](https://f.cloud.github.com/assets/124687/617913/846193c8-cea6-11e2-9158-a99eef5db697.png)

And here's the new "bulk actions" form at the bottom of the claim code management page:

![screen shot 2013-06-06 at 9 56 17 am](https://f.cloud.github.com/assets/124687/618281/019652ac-ceb1-11e2-9703-dae2e9737219.png)

The supported bulk actions are exporting distributable claim codes to a text file, and exporting them to a printable handout that looks like this:

![screen shot 2013-06-06 at 3 50 15 pm](https://f.cloud.github.com/assets/124687/620366/7a8d9586-cee2-11e2-828d-280d256c1b0f.png)

The `OPENBADGER_CLAIM_URL_TEXT` environment variable must be defined in order for the handouts to have a URL on them; otherwise they just say "go to the website" rather than e.g. "go to csol.org/claim".

We can add more bulk actions in the future, such as showing statistics on how many claim codes in a batch were actually redeemed, and so forth.
