### PR TITLE
Award API can take evidence

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -283,6 +283,7 @@ Award a badge directly to a user.
 ### Request Parameters
 * **auth**: The JWT corresponding to the user making the request.
 * **email**: The email of the relevant user.
+* **evidence**: A URL pointing to evidence for the badge.
 
 
 ### Response Codes

--- a/models/badge-instance.js
+++ b/models/badge-instance.js
@@ -6,7 +6,7 @@ const Schema = mongoose.Schema;
 const util = require('../lib/util');
 
 const regex = {
-  email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/
+  email: /[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+(?:\.[a-z0-9!#$%&'*+\/=?\^_`{|}~\-]+)*@(?:[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9\-]*[a-z0-9])?/i
 };
 
 const BadgeInstanceSchema = new Schema({

--- a/models/badge.js
+++ b/models/badge.js
@@ -415,12 +415,14 @@ Badge.prototype.award = function award(options, callback) {
   const DUP_KEY_ERROR_CODE = 11000;
   const checkForCategoryBadges =
     !this.categoryAward && this.categoryWeight;
-  const email = options.user;
+  const email = options.user || options.email;
   const categories = this.categories;
   const weight = this.weight;
+  const evidence = options.evidence;
   const instance = new BadgeInstance({
     user: email,
     badge: this.id,
+    evidence: evidence,
   });
 
   // We don't want to fail with an error if the user already has the

--- a/routes/api.js
+++ b/routes/api.js
@@ -310,17 +310,22 @@ function tryAwardingBadge(badge, email, res, successCb) {
         reason: 'database'
       });
     }
+
     if (!instance)
       return res.json(409, {
         status: 'error',
         reason: util.format('user `%s` already has badge', email),
         user: email,
       });
+
     var success = res.send.bind(res, 200, {
       status: 'ok',
       url: instance.absoluteUrl('assertion'),
     });
-    if (successCb) successCb(success); else success();
+
+    if (successCb)
+      return successCb(success);
+    return success();
   });
 }
 


### PR DESCRIPTION
This addresses some stuff in #177. The original issue was fixed by another commit, but we talked about getting evidence in the instance, so I added some tests and implementation for that.
