### PR TITLE
Be graceful if badge has no categories.

### DIFF
--- a/models/badge.js
+++ b/models/badge.js
@@ -683,7 +683,7 @@ Badge.getRecommendations = function (opts, callback) {
 };
 
 Badge.prototype.getSimilar = function (email, callback) {
-  const defer = setImmediate || process.nextTick;
+  const defer = global.setImmediate || process.nextTick;
   const wrap = util.objWrap;
   const thisShortname = this.shortname;
   const categories = this.categories;

--- a/models/badge.js
+++ b/models/badge.js
@@ -683,12 +683,26 @@ Badge.getRecommendations = function (opts, callback) {
 };
 
 Badge.prototype.getSimilar = function (email, callback) {
+  const defer = setImmediate || process.nextTick;
+  const wrap = util.objWrap;
   const thisShortname = this.shortname;
+  const categories = this.categories;
+
   if (typeof email == 'function')
     callback = email, email = null;
-  const query = {
-    '$or': this.categories.map(util.objWrap('categories'))
-  };
+
+  const noCategories = !categories || categories.length == 0;
+
+  if (noCategories) {
+    return defer(function () {
+      callback(null, []);
+    });
+  }
+
+  // This builds up an array of objects that looks something like
+  // this: [{categories: 'science'}, {categories: 'math'}].
+  const query = { '$or': categories.map(wrap('categories')) };
+
   Badge.find(query, function (err, badges) {
     if (err) return callback(err);
 

--- a/tests/badge-recommendations.test.js
+++ b/tests/badge-recommendations.test.js
@@ -13,7 +13,7 @@ const ALL_AGES = [Badge.KID, Badge.TEEN, Badge.ADULT];
 const TODAY = new Date('2013-06-03');
 
 function createBadge(id, obj) {
-  return new Badge(_.defaults(obj, {
+  return new Badge(_.defaults(obj||{}, {
     _id: id,
     shortname: id,
     name: 'badge',
@@ -118,6 +118,9 @@ test.applyFixtures({
   'earned-badge': createBadge('earned', {
     categories: ['science', 'math'],
   }),
+  'no-categories-badge': createBadge('no-categories', {
+    categories: null,
+  }),
 
   // Instances
   'earned-badge-instance': new BadgeInstance({
@@ -153,6 +156,15 @@ test.applyFixtures({
 
       t.same(hasMath, false, 'should not have math');
       t.same(hasEarned, false, 'should not have the earned badge');
+      t.end();
+    });
+  });
+
+  test('similar badges, no user, no categories', function (t) {
+    const noCategories = fx['no-categories-badge'];
+    noCategories.getSimilar(function (err, badges) {
+      t.notOk(err, 'no errors');
+      t.same(badges, [], 'should be an empty array');
       t.end();
     });
   });
@@ -203,7 +215,6 @@ test.applyFixtures({
       t.equal(lastElem(names), 'offline-science',
               'should recommend offline badges last');
 
-      console.dir(names);
       t.end();
     });
   });


### PR DESCRIPTION
Fixes #181

`getSimilar` was assuming there would always be at least one STEAM category associated with a badge. That was not a good assumption.

Note: this was actually fixed earlier, by 7ef55c228165fc8e02b45314c3a2a4d6fd5cc24f, but the "fix" still passed back an error. This is more graceful in that it detects if there are no categories early and calls back with an empty set.
