### PR TITLE
Don't provide imageUrls unless there are images.

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -54,6 +54,7 @@ function normalizeProgram(program) {
   if (!(program.issuer && typeof(program.issuer) == "object"))
     throw new Error("expected populated program issuer");
 
+  const issuer = program.issuer;
   var programData = [
     'shortname',
     'name',
@@ -66,12 +67,17 @@ function normalizeProgram(program) {
   ].reduce(function (out, field) {
     return (out[field] = program[field], out);
   }, {});
-  programData.imageUrl = program.absoluteUrl('image');
+
+  if (program.image)
+    programData.imageUrl = program.absoluteUrl('image');
+
   programData.issuer = {
-    name: program.issuer.name,
-    url: program.issuer.url,
-    imageUrl: program.issuer.absoluteUrl('image')
+    name: issuer.name,
+    url: issuer.url,
   };
+
+  if (issuer.image)
+    programData.issuer.imageUrl = issuer.absoluteUrl('image');
 
   return programData;
 }

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -131,6 +131,23 @@ test.applyFixtures(badgeFixtures, function(fx) {
     });
   });
 
+  test('api does not provide images when they do not exist', function(t) {
+    conmock({
+      handler: api.badge,
+      request: {
+        badge: fx['no-image-badge']
+      }
+    }, function(err, mockRes, req) {
+      const badge = mockRes.body.badge;
+      t.notOk(badge.program.imageUrl,
+              'should not have program image url');
+      t.notOk(badge.program.issuer.imageUrl,
+              'should not have issuer image url');
+      t.end();
+    });
+  });
+
+
   test('api provides unclaimed badge info given claim code', function(t) {
     conmock({
       handler: api.getUnclaimedBadgeInfoFromCode,

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -14,6 +14,7 @@ module.exports = {
     name: 'Badge Authority',
     contact: 'brian@example.org',
     url: 'http://badgeauthority.org',
+    image: IMAGE,
     programs: [
       {name: 'Org 1'},
       {name: 'Org 2'},
@@ -24,6 +25,27 @@ module.exports = {
     name: 'Some Program',
     issuer: 'issuer',
     url: 'http://example.org/program',
+    image: IMAGE,
+  }),
+  'no-image-issuer': new Issuer({
+    _id: 'no-image-issuer',
+    name: 'No Image Issuer',
+    contact: 'brian@example.org',
+    url: 'http://no-image.example.org',
+  }),
+  'no-image-program': new Program({
+    _id: 'no-image-program',
+    name: 'no image program',
+    issuer: 'no-image-issuer',
+    url: 'http://example.org/program',
+  }),
+  'no-image-badge': new Badge({
+    program: 'no-image-program',
+    name: 'Program with no image',
+    shortname: 'no-image-badge',
+    description: 'desc',
+    image: IMAGE,
+    program: 'no-image-program',
   }),
   'link-basic': new Badge({
     _id: 'bba3989d4825d81b5587f96b7d8ba6941d590fff',


### PR DESCRIPTION
Fixes #201 

The API was previously providing `imageUrl`s for programs and issuers even when that imageUrl would 404. This is a little smarter about checking to see if there is an image before providing an imageUrl, that way we can fall back to defaults on CSOL.

@curlee to review
