### PR TITLE
Fix image thing again

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -223,4 +223,14 @@ util.negate = function negate(fn) {
   };
 };
 
+util.empty = function empty(thing) {
+  if (!thing)
+    return true;
+  if (Array.isArray(thing) || typeof thing == 'string')
+    return !thing.length;
+  if (typeof thing == 'object')
+    return !Object.keys(thing).length;
+  return !thing;
+};
+
 module.exports = util;

--- a/lib/util.js
+++ b/lib/util.js
@@ -226,7 +226,9 @@ util.negate = function negate(fn) {
 util.empty = function empty(thing) {
   if (!thing)
     return true;
-  if (Array.isArray(thing) || typeof thing == 'string')
+  if (Array.isArray(thing) ||
+      typeof thing == 'string' ||
+      Buffer.isBuffer(thing))
     return !thing.length;
   if (typeof thing == 'object')
     return !Object.keys(thing).length;

--- a/routes/api.js
+++ b/routes/api.js
@@ -557,13 +557,10 @@ exports.programs = function programs(req, res) {
         status: 'ok',
         programs: programs.map(function (program) {
           const programData = normalizeProgram(program);
-          const imageUrl = empty(program.image)
-            ? null
-            : programData.imageUrl;
           return {
             name: programData.name,
             shortname: programData.shortname,
-            imageUrl: imageUrl,
+            imageUrl: programData.imageUrl,
             issuer: programData.issuer
           };
         })

--- a/routes/api.js
+++ b/routes/api.js
@@ -55,6 +55,8 @@ function normalizeProgram(program) {
     throw new Error("expected populated program issuer");
 
   const issuer = program.issuer;
+  const empty = util.empty;
+
   var programData = [
     'shortname',
     'name',
@@ -68,7 +70,7 @@ function normalizeProgram(program) {
     return (out[field] = program[field], out);
   }, {});
 
-  if (program.image)
+  if (!empty(program.image))
     programData.imageUrl = program.absoluteUrl('image');
 
   programData.issuer = {
@@ -76,7 +78,7 @@ function normalizeProgram(program) {
     url: issuer.url,
   };
 
-  if (issuer.image)
+  if (!empty(issuer.image))
     programData.issuer.imageUrl = issuer.absoluteUrl('image');
 
   return programData;
@@ -541,6 +543,7 @@ exports.issuer = function issuer(req, res, next) {
 };
 
 exports.programs = function programs(req, res) {
+  const empty = util.empty;
   Program.find({})
     .populate('issuer')
     .exec(function(err, programs) {
@@ -554,10 +557,13 @@ exports.programs = function programs(req, res) {
         status: 'ok',
         programs: programs.map(function (program) {
           const programData = normalizeProgram(program);
+          const imageUrl = empty(program.image)
+            ? null
+            : programData.imageUrl;
           return {
             name: programData.name,
             shortname: programData.shortname,
-            imageUrl: program.image ? programData.imageUrl : null,
+            imageUrl: imageUrl,
             issuer: programData.issuer
           };
         })

--- a/routes/api.js
+++ b/routes/api.js
@@ -543,7 +543,6 @@ exports.issuer = function issuer(req, res, next) {
 };
 
 exports.programs = function programs(req, res) {
-  const empty = util.empty;
   Program.find({})
     .populate('issuer')
     .exec(function(err, programs) {

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -32,12 +32,14 @@ module.exports = {
     name: 'No Image Issuer',
     contact: 'brian@example.org',
     url: 'http://no-image.example.org',
+    image: Buffer(0),
   }),
   'no-image-program': new Program({
     _id: 'no-image-program',
     name: 'no image program',
     issuer: 'no-image-issuer',
     url: 'http://example.org/program',
+    image: Buffer(0),
   }),
   'no-image-badge': new Badge({
     program: 'no-image-program',

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -134,6 +134,7 @@ test('util.empty', function (t) {
    null,
    undefined,
    NaN,
+   Buffer(0),
    [],
    {}
   ].forEach(function (thing) {

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -128,3 +128,19 @@ test('util.prop', function (t) {
   t.same(arr.map(prop('does', 'not', 'exist')), [undefined, undefined, undefined]);
   t.end();
 });
+
+test('util.empty', function (t) {
+  [false,
+   null,
+   undefined,
+   NaN,
+   [],
+   {}
+  ].forEach(function (thing) {
+    t.ok(util.empty(thing), 'thing should be empty');
+   });
+  ['1', true, {hi:'hi'}, [1,2]].forEach(function (thing) {
+    t.notOk(util.empty(thing), 'thing should not be empty');
+  });
+  t.end();
+});


### PR DESCRIPTION
While my previous patch to make sure images were existent before trying to form an imageUrl worked if there was no image set at all, in the real world an image is _always_ set, only sometimes it might be set to a zero-length buffer. This takes that into account.
