### PR TITLE
Added webhook testing API endpoint at `/v2/test/webhook`.

### DIFF
--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -14,9 +14,10 @@ const FAKE_WEBHOOK = IS_TESTING || (process.env.NODE_ENV === 'development' && !W
 // Exporting these is primarily intended for test suites to stub/override.
 exports.request = require('request');
 exports.webhookUrl = WEBHOOK_URL;
+exports.jwtSecret = JWT_SECRET;
 
 if (FAKE_WEBHOOK) {
-  JWT_SECRET = 'asecrettoeveryone';
+  exports.jwtSecret = 'asecrettoeveryone';
   exports.request = { post: function(opts, callback) {
     if (!IS_TESTING) logger.log('debug', 'FAKE WEBHOOK REQUEST: request post with opts', opts);
     callback(null, { statusCode: 200 },  { status: 'ok' });
@@ -28,7 +29,7 @@ function getJWTToken(email) {
     prn: email,
     exp: Date.now() + TOKEN_LIFETIME
   };
-  return jwt.encode(claims, JWT_SECRET);
+  return jwt.encode(claims, exports.jwtSecret);
 }
 
 exports.notifyOfReservedClaim = function notifyOfReservedClaim(email, claimCode, callback, isTesting) {

--- a/lib/webhooks.js
+++ b/lib/webhooks.js
@@ -3,7 +3,6 @@ const url = require('url');
 const jwt = require('jwt-simple');
 const logger = require('./logger.js');
 const util = require('./util.js');
-var request = require('request');
 
 var JWT_SECRET = env.get('JWT_SECRET');
 const WEBHOOK_URL = env.get('NOTIFICATION_WEBHOOK');
@@ -12,9 +11,13 @@ const TOKEN_LIFETIME = process.env['WEBHOOK_TOKEN_LIFETIME'] || 10000;
 const IS_TESTING = (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'travis');
 const FAKE_WEBHOOK = IS_TESTING || (process.env.NODE_ENV === 'development' && !WEBHOOK_URL);
 
+// Exporting these is primarily intended for test suites to stub/override.
+exports.request = require('request');
+exports.webhookUrl = WEBHOOK_URL;
+
 if (FAKE_WEBHOOK) {
   JWT_SECRET = 'asecrettoeveryone';
-  request = { post: function(opts, callback) {
+  exports.request = { post: function(opts, callback) {
     if (!IS_TESTING) logger.log('debug', 'FAKE WEBHOOK REQUEST: request post with opts', opts);
     callback(null, { statusCode: 200 },  { status: 'ok' });
   }};
@@ -28,21 +31,22 @@ function getJWTToken(email) {
   return jwt.encode(claims, JWT_SECRET);
 }
 
-exports.notifyOfReservedClaim = function notifyOfReservedClaim(email, claimCode, callback) {
-  callback = callback || function(err){ if (err) logger.log('info', util.format('Failed to notify %s of claim code %s for email %s.  %s', WEBHOOK_URL, claimCode, email, err)); };
+exports.notifyOfReservedClaim = function notifyOfReservedClaim(email, claimCode, callback, isTesting) {
+  callback = callback || function(err){ if (err) logger.log('info', util.format('Failed to notify %s of claim code %s for email %s.  %s', exports.webhookUrl, claimCode, email, err)); };
 
   var params = {
     auth: getJWTToken(email),
     email: email,
-    claimCode: claimCode
+    claimCode: claimCode,
+    isTesting: !!isTesting
   };
 
   var opts = {
-      url: WEBHOOK_URL,
+      url: exports.webhookUrl,
       json: params
   };
 
-  request.post(opts, function (err, response, body) {
+  exports.request.post(opts, function (err, response, body) {
     if (err)
       return callback(err);
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "tap": "~0.4.1",
     "colors": "0.6.0",
+    "sinon": "1.7.2",
     "supertest": "0.6.0",
     "prompt": "0.2.9",
     "mime": "~1.2.5"

--- a/routes/api.js
+++ b/routes/api.js
@@ -4,6 +4,7 @@ const jwt = require('jwt-simple');
 const urlutil = require('url');
 const env = require('../lib/environment');
 const util = require('../lib/util');
+const webhooks = require('../lib/webhooks');
 const Badge = require('../models/badge');
 const User = require('../models/user');
 const BadgeInstance = require('../models/badge-instance');
@@ -646,6 +647,20 @@ exports.program = function program(req, res) {
       });
     });
   });
+};
+
+exports.testWebhook = function testWebhook(req, res) {
+  webhooks.notifyOfReservedClaim(req.body.email, req.body.claimCode, function(err, body) {
+    if (err)
+      return res.json(502, {
+        status: 'error',
+        error: err.toString()
+      });
+    return res.json(200, {
+      status: 'ok',
+      body: body
+    });
+  }, true);
 };
 
 /**

--- a/routes/index.js
+++ b/routes/index.js
@@ -229,6 +229,7 @@ exports.define = function defineRoutes(app) {
 
   app.get('/v2/program/:programShortName', api.program);
   app.get('/v2/issuer/:issuerShortName', api.issuer);
+  app.post('/v2/test/webhook', api.testWebhook);
 
   // Resources
   app.get('/issuer/image/:issuerId', [

--- a/routes/index.js
+++ b/routes/index.js
@@ -229,7 +229,7 @@ exports.define = function defineRoutes(app) {
 
   app.get('/v2/program/:programShortName', api.program);
   app.get('/v2/issuer/:issuerShortName', api.issuer);
-  app.post('/v2/test/webhook', api.testWebhook);
+  app.post('/v2/test/webhook', [api.auth()], api.testWebhook);
 
   // Resources
   app.get('/issuer/image/:issuerId', [

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,4 +1,5 @@
 const sinon = require('sinon');
+const jwt = require('jwt-simple');
 const test = require('./');
 const conmock = require('./conmock');
 const badgeFixtures = require('./badge-model.fixtures');
@@ -424,9 +425,13 @@ test.applyFixtures(badgeFixtures, function(fx) {
   });
 
   test('api can be used to test webhook success', function(t) {
-    t.plan(5);
+    t.plan(7);
     webhooks.webhookUrl = 'http://mywebhook/blah';
+    webhooks.jwtSecret = 'somekindasecret';
     sinon.stub(webhooks.request, 'post', function(options, cb) {
+      var auth = jwt.decode(options.json.auth, 'somekindasecret');
+      t.same(auth.prn, 'test@test.com');
+      t.ok(auth.exp > Date.now());
       t.same(options.url, 'http://mywebhook/blah');
       t.same(options.json.email, "test@test.com");
       t.same(options.json.claimCode, "TESTING");

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,3 +1,4 @@
+const sinon = require('sinon');
 const test = require('./');
 const conmock = require('./conmock');
 const badgeFixtures = require('./badge-model.fixtures');
@@ -8,6 +9,7 @@ const BadgeInstance = require('../models/badge-instance');
 const db = require('../models');
 const api = require('../routes/api');
 const env = require('../lib/environment');
+const webhooks = require('../lib/webhooks');
 
 function ensureAlreadyClaimedError(t) {
   return function(err, mockRes, req) {
@@ -417,6 +419,52 @@ test.applyFixtures(badgeFixtures, function(fx) {
     }, function(err, mockRes, req) {
       const badges = mockRes.body.badges;
       t.ok(badges.length == 2, 'should have exactly two badges');
+      t.end();
+    });
+  });
+
+  test('api can be used to test webhook success', function(t) {
+    t.plan(5);
+    webhooks.webhookUrl = 'http://mywebhook/blah';
+    sinon.stub(webhooks.request, 'post', function(options, cb) {
+      t.same(options.url, 'http://mywebhook/blah');
+      t.same(options.json.email, "test@test.com");
+      t.same(options.json.claimCode, "TESTING");
+      t.equal(options.json.isTesting, true);
+      cb(null, {statusCode: 200}, "lolol");
+    });
+    conmock({
+      handler: api.testWebhook,
+      request: {
+        body: {
+          email: 'test@test.com',
+          claimCode: 'TESTING'
+        }
+      }
+    }, function(err, mockRes, req) {
+      webhooks.request.post.restore();
+      if (err) throw err;
+      t.same(mockRes.body, {status: "ok", body: "lolol"});
+      t.end();
+    });
+  });
+
+  test('api can be used to test webhook failure', function(t) {
+    sinon.stub(webhooks.request, 'post', function(options, cb) {
+      cb(null, {statusCode: 500}, "OOF");
+    });
+    conmock({
+      handler: api.testWebhook,
+      request: {
+        body: {
+          email: 'test@test.com',
+          claimCode: 'TESTING'
+        }
+      }
+    }, function(err, mockRes, req) {
+      webhooks.request.post.restore();
+      if (err) throw err;
+      t.same(mockRes.body, {status: "error", error: "OOF"});
       t.end();
     });
   });


### PR DESCRIPTION
This simply passes the `email` and `claimCode` given by the client on to
the `OPENBADGER_NOTIFICATION_WEBHOOK`, and returns a 200 OK response if
the webhook returns 200, a 502 bad gateway response otherwise. Additionally,
the body of the payload to the webhook contains the parameter `isTesting` set
to `true`, so that the webhook endpoint knows not to treat the ping
seriously. The API endpoint only returns a response when the webhook
notification has completed.

A robust health check on the openbadger client might create a DB entry
for a fake claim code and have their webhook remove it when it is
pinged and `isTesting` is set to `true`. The client could then ping
`/v2/test/webhook` with the fake claim code, and then ensure that
both the response is OK and the claim code no longer exists in
its db.

@christensenep, any thoughts on this?
