### PR TITLE
Add search for badges, programs to the API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -118,6 +118,10 @@ Get information about all existing badge classes.
 
 This is needed by applications to show information about available badges to users. It requires no authorization.
 
+### Request Parameters
+* **search**: (Optional) Filter out badges whose name isn't like the given string. "Likeness" is determined by generating a case-insensitive, unbounded regexp (i.e., `new Regexp(searchTerm, 'i')`).
+
+
 ### Example
 This endpoint returns `200 OK`:
 
@@ -481,25 +485,28 @@ This is needed by the CSOL About page to show the organizations involved in the 
 ## GET `/v2/programs`
 Get information about all existing programs.
 
-### Filters
-If specified, results should only include entries where the entry value matches or includes the filter value.
+### Request Parameters
+All request parameters are optional.
 
-  * `issuer` - issuer shortname
-  * `tags` - list of tags the entry must have all of\*\*
+* **search**: Filter out programs whose name isn't like the given string. "Likeness" is determined by generating a case-insensitive, unbounded regexp (i.e., `new Regexp(searchTerm, 'i')`).
+* **org**: Valid inputs are issuer shortnames.
+* **category**: Category, generally one of "science", "technology", "engineering", "arts" or "math".
+* **age**: Valid age ranges: "0-13", "13-18", "19-24".
+* **activity**: Either "offline" or "online"
 
-\*\* _This assumes CSOL filters like category, age range, badge type, etc. will all be tags within OpenBadger, rather than building more CSOL-specific data attributes into it. Perhaps [machine tags]!_
 
 ### Example
 ```javascript
 {
   "status": "ok",
-  "programs": {
-    "prog-a": {
+  "programs": [
+    {
+      "shortname": "prog-a",
       "image": "http://some.org/program/image",
       "name": "My Program",
     },
     ...
-  }
+  ]
 }
 ```
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -235,4 +235,16 @@ util.empty = function empty(thing) {
   return !thing;
 };
 
+util.makeSearch = function (fields) {
+  const prop = util.prop;
+  return function searchFn(regex) {
+    return function filter(item) {
+      return fields.reduce(function (res, field) {
+        const value = prop.apply(null, field.split('.'))(item);
+        return res || regex.test(value);
+      }, false);
+    };
+  };
+};
+
 module.exports = util;

--- a/lib/util.js
+++ b/lib/util.js
@@ -238,6 +238,8 @@ util.empty = function empty(thing) {
 util.makeSearch = function (fields) {
   const prop = util.prop;
   return function searchFn(regex) {
+    if (typeof regex === 'string')
+      regex = new RegExp(regex, 'i');
     return function filter(item) {
       return fields.reduce(function (res, field) {
         const value = prop.apply(null, field.split('.'))(item);

--- a/routes/api.js
+++ b/routes/api.js
@@ -97,6 +97,7 @@ exports.badges = function badges(req, res) {
   }
   const result = { status: 'ok', badges : {} };
   const searchTerm = req.query.search;
+  const propertiesToMatch = ['name'];
   Badge.find(function (err, badges) {
     if (err) return handleError(err);
 
@@ -105,7 +106,7 @@ exports.badges = function badges(req, res) {
     });
 
     if (searchTerm) {
-      const searchFn = util.makeSearch(['name']);
+      const searchFn = util.makeSearch(propertiesToMatch);
       filteredBadges = filteredBadges.filter(searchFn(searchTerm));
     }
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -12,6 +12,7 @@ const BadgeInstance = require('../models/badge-instance');
 const Program = require('../models/program');
 const Issuer = require('../models/issuer');
 const mongoose = require('mongoose');
+const log = require('../lib/logger');
 
 function normalizeBadge(badge) {
   var badgeData = {
@@ -89,20 +90,29 @@ function normalizeProgram(program) {
 exports.jwtSecret = null;
 exports.limitedJwtSecret = null;
 
-/**
- * Get listing of all badges
- */
-
 exports.badges = function badges(req, res) {
-  var result = { status: 'ok', badges : {} };
+  function handleError(err) {
+    log.error(err);
+    return res.send(500, { status: 'error', error: err });
+  }
+  const result = { status: 'ok', badges : {} };
+  const searchTerm = req.query.search;
   Badge.find(function (err, badges) {
-    if (err)
-      return res.send(500, { status: 'error', error: err });
-    badges.filter(function (badge) {
+    if (err) return handleError(err);
+
+    var filteredBadges = badges.filter(function (badge) {
       return !badge.doNotList;
-    }).forEach(function (badge) {
+    });
+
+    if (req.query.search) {
+      const searchFn = util.makeSearch(['name']);
+      filteredBadges = filteredBadges.filter(searchFn(searchTerm));
+    }
+
+    filteredBadges.forEach(function (badge) {
       result.badges[badge.shortname] = normalizeBadge(badge);
     });
+
     return res.send(200, result);
   });
 };
@@ -150,7 +160,7 @@ exports.badgeRecommendations = function badgeRecommendations(req, res, next) {
   }, function (err, badges) {
     if (err) return res.json(500, {status: 'error', error: err });
     return res.json(200, {
-      status: 'okay',
+      status: 'ok',
       badges: badges.map(normalizeBadge),
     });
   });
@@ -644,6 +654,10 @@ function createFilterFn(query) {
 
       if (query.activity &&
           !_.contains(activityTypes, query.activity))
+        return cb(false);
+
+      if (query.search &&
+          !(new RegExp(query.search, 'i')).test(program.name))
         return cb(false);
 
       return cb(true);

--- a/routes/api.js
+++ b/routes/api.js
@@ -104,7 +104,7 @@ exports.badges = function badges(req, res) {
       return !badge.doNotList;
     });
 
-    if (req.query.search) {
+    if (searchTerm) {
       const searchFn = util.makeSearch(['name']);
       filteredBadges = filteredBadges.filter(searchFn(searchTerm));
     }

--- a/routes/badge.js
+++ b/routes/badge.js
@@ -22,7 +22,7 @@ function handleModelSaveError(err, res, next) {
       422,
       "A validation error occurred on the following fields: " +
       Object.keys(err.errors).sort().map(function(name) {
-        return name + " (" + err.errors[name].type + ")"
+        return name + " (" + err.errors[name].type + ")";
       }).join(", ") + "."
     );
   return next(err);

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -398,6 +398,18 @@ test.applyFixtures(badgeFixtures, function(fx) {
     });
   });
 
+  test('api provides searchable program listing', function (t) {
+    conmock({
+      handler: api.programs,
+      request: { query: { search: 'no image' } }
+    }, function (err, mockRes, req) {
+      const programs = mockRes.body.programs;
+      t.same(programs.length, 1, 'should have just one result');
+      t.same(programs[0].shortname, 'no-image-program');
+      t.end();
+    });
+  });
+
   test('api can filter program listing', function (t) {
     const expect = fx['filterable-program'];
     conmock({
@@ -573,6 +585,20 @@ test.applyFixtures(badgeFixtures, function(fx) {
       });
     });
   });
+
+  test('api can give & search a list of badges', function (t) {
+    conmock({
+      handler: api.badges,
+      request: { query: { search: 'comment' }}
+    }, function (err, mockRes, req) {
+      t.ok(mockRes.body.badges['link-comment']);
+      t.ok(mockRes.body.badges['comment']);
+      t.notOk(mockRes.body.badges['offline-badge']);
+      t.notOk(mockRes.body.badges['random-badge']);
+      t.end();
+    });
+  });
+
 
   test('**badge recommendation stub**', function (t) {
     conmock({

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -171,7 +171,7 @@ test('util.makeSearch', function (t) {
     'data.thing.non-existant'
   ]);
   const results = items
-    .filter(searchFn(/ham/i))
+    .filter(searchFn('ham'))
     .map(util.prop('data', 'name'));
   const expect = ['ham', 'sandwich', 'Ham Rove', 'ShamWow!'];
   t.same(results, expect, 'results should match expectation');

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -153,3 +153,27 @@ test('util.empty', function (t) {
   });
   t.end();
 });
+
+
+test('util.makeSearch', function (t) {
+  const items = [
+    {data: {name: 'ham', type: 'meat'}},
+    {data: {name: 'steak', type: 'meat'}},
+    {data: {name: 'sandwich', type: 'foodstuff', ingredients: ['ham', 'bread']}},
+    {data: {name: 'Ham Rove', type: 'politician'}},
+    {data: {name: 'Jimmy Carter', type: 'politician'}},
+    {data: {name: 'cornballer', type: 'product'}},
+    {data: {name: 'ShamWow!', type: 'product'}}
+  ];
+  const searchFn = util.makeSearch([
+    'data.name',
+    'data.ingredients',
+    'data.thing.non-existant'
+  ]);
+  const results = items
+    .filter(searchFn(/ham/i))
+    .map(util.prop('data', 'name'));
+  const expect = ['ham', 'sandwich', 'Ham Rove', 'ShamWow!'];
+  t.same(results, expect, 'results should match expectation');
+  t.end();
+});


### PR DESCRIPTION
Fixes #236.

This adds recognition for the `search` query parameter to `/v2/badges` and `/v2/programs`. 

Currently the search is only effective against the `name` property. I can adjust that if necessary.

Note, we still don't have categorical filtering on `/v2/badges` – currently the only way to filter is with search terms. I'm not sure if the frontend of CSOL requires categorical filtering (like we have for programs – things like age range, type of activity, categories, etc.); if so, we should open another ticket for it.

@cmcavoy to review.
