### PR TITLE
Fix unpopulated programs error

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -6,7 +6,20 @@ const log = module.exports = bunyan.createLogger({
   level: 'info',
   serializers: {
     req: bunyan.stdSerializers.req,
-    res: bunyan.stdSerializers.res
+    res: bunyan.stdSerializers.res,
+    program: function (p) {
+      return {
+        shortname: p.shortname,
+        name: p.name,
+        description: p.description,
+        url: p.url,
+        contact: p.contact,
+        startDate: p.startDate,
+        endDate: p.endDate,
+        phone: p.phone,
+        issuer: p.issuer,
+      };
+    }
   }
 });
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -54,8 +54,10 @@ function inflateBadge(badge, cb) {
 }
 
 function normalizeProgram(program) {
-  if (!(program.issuer && typeof(program.issuer) == "object"))
+  if (!(program.issuer && typeof(program.issuer) == "object")) {
+    log.fatal({program: program}, "PRE-CRASH: unpopulated program");
     throw new Error("expected populated program issuer");
+  }
 
   const issuer = program.issuer;
   const empty = util.empty;

--- a/routes/api.js
+++ b/routes/api.js
@@ -622,15 +622,18 @@ function createFilterFn(query) {
   const prop = util.prop;
 
   return function filterProgram(program, cb) {
+    // immediately reject orphaned programs
+    if (!program.issuer)
+      return cb(false);
+
     if (!_.keys(query).length)
       return cb(true);
 
     program.findBadges(function (err, badges) {
-      if (err)
+      if (err) {
+        log.error(err, 'could not find badges for a program');
         return cb(false);
-      // remove orphaned programs
-      if (!program.issuer)
-        return cb(false);
+      }
       const organization = program.issuer.shortname;
       const categories = _.chain(badges)
         .map(prop('categories'))

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -410,6 +410,18 @@ test.applyFixtures(badgeFixtures, function(fx) {
     });
   });
 
+  test('api does not crash with orphaned programs', function (t) {
+    conmock({
+      handler: api.programs,
+      request: {}
+    }, function (err, mockRes, req) {
+      const programs = mockRes.body.programs;
+      t.ok(programs.length);
+      t.end();
+    });
+  });
+
+
   test('api can filter program listing', function (t) {
     const expect = fx['filterable-program'];
     conmock({

--- a/tests/badge-model.fixtures.js
+++ b/tests/badge-model.fixtures.js
@@ -28,6 +28,13 @@ module.exports = {
     url: 'http://example.org/program',
     image: IMAGE,
   }),
+  'orphaned-program': new Program({
+    _id: 'orphaned-program',
+    name: 'Orphaned Program',
+    issuer: null,
+    url: 'http://example.org/program',
+    image: IMAGE,
+  }),
   'filterable-program': new Program({
     _id: 'filterable-program',
     shortname: 'filterable-program',


### PR DESCRIPTION
Fixes #241 

This fixes the filtering algorithm on programs so the first step is to reject unpopulated programs. While this was in the algorithm before, it was being short circuited by the test to see if there were any query parameters, so a call to `/v2/programs` when there were orphans would succeed if there was a query and fail if there was not.

@cmcavoy to review
