### PR TITLE
Do not list `doNotList` badges in API.

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -717,7 +717,10 @@ exports.program = function program(req, res) {
         return res.send(500, "There was an error retrieving issuer info");
       var programData = normalizeProgram(program);
       programData.earnableBadges = {};
-      Badge.find({program: program._id}, function(err, badges) {
+      Badge.find({
+        program: program._id,
+        doNotList: {'$ne': true }
+      }, function(err, badges) {
         if (err)
           return res.send(500, "There was an error getting earnable badges");
         badges.forEach(function(badge) {

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -611,12 +611,24 @@ test.applyFixtures(badgeFixtures, function(fx) {
     });
   });
 
-  test('api does not list `doNotList` badges', function (t) {
+  test('api endpoint for all badges does not list `doNotList` badges', function (t) {
     conmock({
       handler: api.badges,
-      request: { query: { search: 'comment' }}
     }, function (err, mockRes, req) {
       t.notOk(mockRes.body.badges['do-not-list-badge']);
+      t.end();
+    });
+  });
+
+  test('api endpoint for a specific program does not list `doNotList` badges', function (t) {
+    conmock({
+      handler: api.program,
+      request: { params: { programShortName: 'some-program' }}
+    }, function (err, mockRes, req) {
+      const badges = mockRes.body.program.earnableBadges;
+      t.notOk(badges['do-not-list-badge'], 'shoud not list badge');
+      t.ok(badges['link-comment']);
+      t.ok(badges['comment']);
       t.end();
     });
   });


### PR DESCRIPTION
Fixes #245 

While we were correctly omitting `doNotList` badges from `/v2/badges`, we neglected to do so for `/v2/program/:shortname`

@cmcavoy to review
