### PR TITLE
Add method for changing the issuing organization of a program

### DIFF
--- a/models/issuer.js
+++ b/models/issuer.js
@@ -118,4 +118,16 @@ Issuer.prototype.getDeletableChildren = function getDeletableChildren(cb) {
   });
 };
 
+Issuer.prototype.removeProgram = function removeProgram(programToRemove, callback) {
+  const needle = typeof programToRemove == 'string'
+    ? programToRemove
+    : programToRemove.id;
+  this.programs = this.programs.filter(function (program) {
+    return (typeof program == 'string'
+            ? needle !== program
+            : needle !== program.id);
+  });
+  this.save(callback);
+};
+
 module.exports = Issuer;

--- a/models/program.js
+++ b/models/program.js
@@ -106,9 +106,9 @@ Program.prototype.findBadges = function findBadges(callback) {
 Program.prototype.changeIssuer = function changeIssuer(newIssuer, callback) {
   const self = this;
 
-  // We are doing everything for sideffects, we don't care about passing
-  // values down the waterfall, so we use `unary(cb)` to ensure the
-  // callback only gets the potential error value.
+  // We don't care about passing values down the waterfall, so we use
+  // `unary(cb)` to make sure that the final callback only gets the
+  // potential error value.
   function unary(fn) {
     return function (arg1) { fn(arg1) };
   }
@@ -132,6 +132,8 @@ Program.prototype.changeIssuer = function changeIssuer(newIssuer, callback) {
     }
   ], callback);
 };
+
+Program.prototype.changeIssuerAndSave = Program.prototype.changeIssuer;
 
 Program.prototype.getDeletableChildren = function getDeletableChildren(cb) {
   this.findBadges(cb);

--- a/models/program.js
+++ b/models/program.js
@@ -103,7 +103,7 @@ Program.prototype.findBadges = function findBadges(callback) {
 };
 
 
-Program.prototype.changeIssuer = function changeIssuer(newIssuer, callback) {
+Program.prototype.changeIssuerAndSave = function changeIssuerAndSave(newIssuer, callback) {
   const self = this;
 
   // We don't care about passing values down the waterfall, so we use
@@ -132,8 +132,6 @@ Program.prototype.changeIssuer = function changeIssuer(newIssuer, callback) {
     }
   ], callback);
 };
-
-Program.prototype.changeIssuerAndSave = Program.prototype.changeIssuer;
 
 Program.prototype.getDeletableChildren = function getDeletableChildren(cb) {
   this.findBadges(cb);

--- a/routes/index.js
+++ b/routes/index.js
@@ -115,8 +115,11 @@ exports.define = function defineRoutes(app) {
     issuer.getUploadedImage()
   ], issuer.newProgram);
   app.all('/admin/program/:programId*', issuer.findProgramById);
-  app.get('/admin/program/:programId', render.editProgramForm);
+  app.get('/admin/program/:programId', [
+    issuer.findAll
+  ],render.editProgramForm);
   app.post('/admin/program/:programId', [
+    issuer.findById,
     issuer.getUploadedImage()
   ], issuer.updateProgram);
   app.delete('/admin/program/:programId', issuer.destroyProgram);

--- a/routes/render.js
+++ b/routes/render.js
@@ -86,6 +86,7 @@ exports.editProgramForm = function (req, res) {
     page: 'edit-program',
     editing: true,
     program:  req.program,
+    issuers: req.issuers,
     user: req.session.user,
     access: req.session.access,
     csrf: req.session._csrf,

--- a/tests/issuer-model.test.js
+++ b/tests/issuer-model.test.js
@@ -34,6 +34,11 @@ test.applyFixtures({
       {email: 'two@example.org'},
     ],
   }),
+  'rm-program-issuer': new Issuer({
+    _id: 'rm-program-issuer',
+    name: 'Detachable Programs',
+    programs: ['program1', 'program2'],
+  }),
   'deleted-issuer': new Issuer({
     _id: 'deleted-issuer',
     name: 'Deleted Issuer',
@@ -208,6 +213,16 @@ test.applyFixtures({
         if (err) throw err;
         t.end();
       });
+    });
+  });
+
+  test('Issuer#removeProgram: by program object', function (t) {
+    const issuer = fixtures['rm-program-issuer'];
+    const program = fixtures['program1'];
+    t.same(issuer.programs.length, 2);
+    issuer.removeProgram(program, function (err) {
+      t.same(issuer.programs.length, 1);
+      t.end();
     });
   });
 

--- a/tests/program-model.test.js
+++ b/tests/program-model.test.js
@@ -18,11 +18,11 @@ test.applyFixtures({
     issuer: 'issuer1',
     url: 'https://example.org/program',
   }),
-}, function (fixtures) {
+}, function (fx) {
 
   test('Finding a program and an issuer', function (t) {
-    const program = fixtures['program'];
-    const issuer = fixtures['issuer'];
+    const program = fx['program'];
+    const issuer = fx['issuer'];
     Program.findOne({'_id': program._id})
       .populate('issuer')
       .exec(function (err, result) {
@@ -32,8 +32,8 @@ test.applyFixtures({
   });
 
   test('Generating issuer json', function (t) {
-    const issuer = fixtures['issuer'];
-    const program = fixtures['program'];
+    const issuer = fx['issuer'];
+    const program = fx['program'];
     const expect =  {
       name: issuer.name,
       org: program.name,

--- a/tests/program-model.test.js
+++ b/tests/program-model.test.js
@@ -60,14 +60,14 @@ test.applyFixtures({
     });
   });
 
-  test('Program#changeIssuer: normal functionality', function (t) {
+  test('Program#changeIssuerAndSave: normal functionality', function (t) {
     const program = fx['program'];
     const oldIssuer = fx['issuer'];
     const newIssuer = fx['issuer2'];
 
     t.same(program.issuer.id, oldIssuer.id);
 
-    program.changeIssuer(newIssuer, function (err) {
+    program.changeIssuerAndSave(newIssuer, function (err) {
       const issuers = [oldIssuer.id, newIssuer.id];
       async.map(issuers, Issuer.findById.bind(Issuer), function (err, iss) {
         const oldPrograms = [].slice.call(iss[0].programs);
@@ -80,10 +80,10 @@ test.applyFixtures({
     });
   });
 
-  test('Program#changeIssuer: do not crash with orphaned program', function (t) {
+  test('Program#changeIssuerAndSave: do not crash with orphaned program', function (t) {
     const program = fx['orphaned-program'];
     const newIssuer = fx['issuer2'];
-    program.changeIssuer(newIssuer, function (err) {
+    program.changeIssuerAndSave(newIssuer, function (err) {
       t.same(program.issuer.id, newIssuer.id);
       t.end();
     });

--- a/tests/program-model.test.js
+++ b/tests/program-model.test.js
@@ -2,20 +2,32 @@ const test = require('./');
 const db = require('../models');
 const Issuer = require('../models/issuer');
 const Program = require('../models/program');
+const util = require('../lib/util');
+const async = require('async');
 
 test.applyFixtures({
   'issuer': new Issuer({
     _id: 'issuer1',
-    uid: 'example-org',
     name: 'Example.org',
     contact: 'a@example.org',
     url: 'https://example.org',
-    description: 'Example Issuer'
+    description: 'Example Issuer',
+    programs: ['program1', 'ghost-program'],
+  }),
+  'issuer2': new Issuer({
+    _id: 'issuer2',
+    name: 'Other Issuer',
   }),
   'program': new Program({
     _id: 'program1',
     name: 'Sample Program',
     issuer: 'issuer1',
+    url: 'https://example.org/program',
+  }),
+  'orphaned-program': new Program({
+    _id: 'orphaned-program',
+    name: 'Orphaned Program',
+    issuer: 'dead-issuer',
     url: 'https://example.org/program',
   }),
 }, function (fx) {
@@ -48,6 +60,34 @@ test.applyFixtures({
     });
   });
 
+  test('Program#changeIssuer: normal functionality', function (t) {
+    const program = fx['program'];
+    const oldIssuer = fx['issuer'];
+    const newIssuer = fx['issuer2'];
+
+    t.same(program.issuer.id, oldIssuer.id);
+
+    program.changeIssuer(newIssuer, function (err) {
+      const issuers = [oldIssuer.id, newIssuer.id];
+      async.map(issuers, Issuer.findById.bind(Issuer), function (err, iss) {
+        const oldPrograms = [].slice.call(iss[0].programs);
+        const newPrograms = [].slice.call(iss[1].programs);
+        t.same(program.issuer.id, newIssuer.id);
+        t.same(oldPrograms, ['ghost-program']);
+        t.same(newPrograms, ['program1']);
+        t.end();
+      });
+    });
+  });
+
+  test('Program#changeIssuer: do not crash with orphaned program', function (t) {
+    const program = fx['orphaned-program'];
+    const newIssuer = fx['issuer2'];
+    program.changeIssuer(newIssuer, function (err) {
+      t.same(program.issuer.id, newIssuer.id);
+      t.end();
+    });
+  });
 
   test('shutting down #', function (t) {
     db.close(); t.end();

--- a/views/admin/create-or-edit-program.html
+++ b/views/admin/create-or-edit-program.html
@@ -15,6 +15,28 @@
       New Program
     {% endif %}
   </legend>
+
+  {% if issuers %}
+    <div>
+      <label for="issuer">Issuing Organization</label>
+
+      <select id="issuer" name="issuerId">
+        {% for issuer in issuers %}
+        <option
+           value="{{ issuer.id }}"
+           {% if issuer.id == program.issuer %}
+           selected
+           {% endif %}>
+
+          {{ issuer.name|e }}
+        </option>
+        {% endfor %}
+      </select>
+      <hr>
+    </div>
+  {% endif %}
+
+
   <div>
     <label for="name">Name</label>
     <input


### PR DESCRIPTION
Fixes #250 

![see](http://i.cloudup.com/hudRU6CeLQ.png)

This introduces the necessary changes for being able to move a program to another organization:
- Change the `program.issuer`
- Remove it from the `oldIssuer.programs` array
- Add it to the `newIssuer.programs` array.

@cmcavoy to review.
