### PR TITLE
adds badge instance count to each line in the badge index. fixes #308

### DIFF
--- a/models/badge.js
+++ b/models/badge.js
@@ -76,6 +76,7 @@ const ClaimCodeSchema = new Schema({
   },
 });
 
+
 const BadgeSchema = new Schema({
   _id: {
     type: String,
@@ -171,6 +172,13 @@ const BadgeSchema = new Schema({
     type: [String]
   },
 });
+
+BadgeSchema.methods.issuedBadgesCount = function(callback) {
+  BadgeInstance.count({badge:this._id}, function(err, count) {
+    callback(err, count);
+  });
+};
+
 const Badge = Deletable(db.model('Badge', BadgeSchema));
 
 Badge.KID = KID;

--- a/routes/render.js
+++ b/routes/render.js
@@ -3,6 +3,7 @@ const Program = require('../models/program');
 const Badge = require('../models/badge');
 const phrases = require('../lib/phrases');
 const logger = require('../lib/logger');
+const async = require('async');
 
 /*
  * Administrative Pages
@@ -115,21 +116,30 @@ exports.newBehaviorForm = function (req, res) {
 };
 
 exports.badgeIndex = function (req, res) {
-  return res.render('admin/badge-index.html', {
-    page: 'home',
+  // get the count of issued badges for each badge
+  async.map(req.badges,
+            function(badge, callback) {
+              badge.issuedBadgesCount(function(err, count) {
+                badge.issuedCount = count;
+                callback(err, badge);
+              });
+            }, function (err, badges) {
+              return res.render('admin/badge-index.html', {
+                page: 'home',
 
-    limit: req.limit,
-    pageNumber: req.page,
-    search: req.query.search,
+                limit: req.limit,
+                pageNumber: req.page,
+                search: req.query.search,
 
-    issuers: req.issuers,
-    user: req.session.user,
-    access: req.session.access,
-    csrf: req.session._csrf,
-    badges: req.badges,
-    undoRecords: req.undoRecords,
-    behaviors: req.behaviors
-  });
+                issuers: req.issuers,
+                user: req.session.user,
+                access: req.session.access,
+                csrf: req.session._csrf,
+                badges: req.badges,
+                undoRecords: req.undoRecords,
+                behaviors: req.behaviors
+              });
+            });
 };
 
 exports.showBadge = function (req, res) {

--- a/views/admin/badge-index.html
+++ b/views/admin/badge-index.html
@@ -27,6 +27,7 @@
 <th class="orga">Organization</th>
 <th class="prog">Program</th>
 <th class="badg">Badge</th>
+<th class="count">Claimed</th>
 <th class="oper all"></th>
 </tr>
 
@@ -43,6 +44,9 @@
     </td>
     <td class="badg">
       <a href="/admin/badge/{{ badge.shortname | e}}">{{ badge.name }}</a>
+    </td>
+    <td class="count">
+      {{badge.issuedCount}}
     </td>
     <td class="oper all">
       <div class="btn-group">


### PR DESCRIPTION
Adds a count of the # of badge instances to the badge index. 
![screenshot from 2013-10-15 16 49 27](https://f.cloud.github.com/assets/64711/1338258/c5158650-35e3-11e3-9d3e-cf6156283891.png)
