### PR TITLE
make the url a required field for issuer

### DIFF
--- a/views/admin/create-or-edit-issuer.html
+++ b/views/admin/create-or-edit-issuer.html
@@ -40,13 +40,14 @@
   </div>
 
   <div>
-    <label for="url">URL (optional)</label>
+    <label for="url">URL</label>
     <input
        id="url"
        type="url"
        name="url"
        value="{{ issuer.url | default('') }}"
-       placeholder="http://example.org">
+       placeholder="http://example.org"
+       required>
   </div>
 
   <div>


### PR DESCRIPTION
this one bites us a lot. It makes invalid assertions if you don't include an issuer url.
