### PR TITLE
adding count of badges to index fixes #320

### DIFF
--- a/routes/render.js
+++ b/routes/render.js
@@ -4,6 +4,7 @@ const Badge = require('../models/badge');
 const phrases = require('../lib/phrases');
 const logger = require('../lib/logger');
 const async = require('async');
+const _ = require('underscore');
 
 /*
  * Administrative Pages
@@ -15,7 +16,7 @@ exports.issuerIndex = function (req, res) {
     badges: req.badges,
     user: req.session.user,
     access: req.session.access,
-    csrf: req.session._csrf,
+    csrf: req.session._csrf
   });
 };
 
@@ -123,7 +124,13 @@ exports.badgeIndex = function (req, res) {
                 badge.issuedCount = count;
                 callback(err, badge);
               });
-            }, function (err, badges) {
+            },
+            function (err, badges) {
+              // get the total badge count
+              var badgeCount = _.reduce(req.badges,
+                                        function(memo, badge) {
+                                          return memo + badge.issuedCount;
+                                        }, 0);
               return res.render('admin/badge-index.html', {
                 page: 'home',
 
@@ -136,6 +143,7 @@ exports.badgeIndex = function (req, res) {
                 access: req.session.access,
                 csrf: req.session._csrf,
                 badges: req.badges,
+                badgeCount: badgeCount,
                 undoRecords: req.undoRecords,
                 behaviors: req.behaviors
               });

--- a/views/admin/badge-index.html
+++ b/views/admin/badge-index.html
@@ -27,7 +27,7 @@
 <th class="orga">Organization</th>
 <th class="prog">Program</th>
 <th class="badg">Badge</th>
-<th class="count">Claimed</th>
+<th class="countTotal">Claimed ({{ badgeCount }} total)</th>
 <th class="oper all"></th>
 </tr>
 


### PR DESCRIPTION
Adds total claimed badges to top bar in admin view. Currently deployed on OBB.

![screenshot from 2013-11-05 12 39 41](https://f.cloud.github.com/assets/64711/1476410/ab011dda-4649-11e3-9054-6eb1e1a1e62f.png)
