### PR TITLE
Move New Relic config into environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ public/.DS_Store
 /surgery
 *.env
 *#*
+todo.txt

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ this at `config.env`, do:
 ```bash
 $ source config.env
 ```
+## New Relic
+
+If you're using New Relic, you'll need to include three additional environment variables.
+
+```NEWRELIC_APPNAME=[the app name you defined in New Relic]
+NEWRELIC_LICENSE=[Your license key]
+NEW_RELIC_ENABLED=true```
 
 ## Adding sample data
 

--- a/newrelic.js
+++ b/newrelic.js
@@ -1,0 +1,11 @@
+// newrelic.js
+var NEWRELIC_LICENSE = process.env('NEWRELIC_LICENSE');
+var NEWRELIC_APPNAME = process.env('NEWRELIC_APPNAME');
+
+exports.config = {
+  app_name: [ NEWRELIC_APPNAME ],
+  license_key: NEWRELIC_LICENSE,
+  logging: {
+    filepath: 'stdout'
+  }
+};


### PR DESCRIPTION
Small change to allow for New Relic monitoring on Heroku. On  AWS we put newrelic.js in /var/www or something and hard code the access key. I moved it to a local file and put the key info into environment variables.
